### PR TITLE
Add RAFT optical flow support

### DIFF
--- a/optical_flow/raft_runner.py
+++ b/optical_flow/raft_runner.py
@@ -1,0 +1,39 @@
+import torch
+import cv2
+import numpy as np
+
+_model = None
+_device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+def _load_model():
+    global _model
+    if _model is None:
+        _model = torch.hub.load('princeton-vl/RAFT', 'raft', pretrained=True)
+        _model = _model.to(_device)
+        _model.eval()
+    return _model
+
+def compute_optical_flow(video_path):
+    """Compute dense optical flow sequence for a video using RAFT."""
+    model = _load_model()
+    cap = cv2.VideoCapture(video_path)
+    ret, prev = cap.read()
+    if not ret:
+        cap.release()
+        return np.empty((0,), np.float32)
+    prev_t = torch.from_numpy(prev).permute(2,0,1).float() / 255.0
+    prev_t = prev_t.unsqueeze(0).to(_device)
+    flows = []
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        cur_t = torch.from_numpy(frame).permute(2,0,1).float() / 255.0
+        cur_t = cur_t.unsqueeze(0).to(_device)
+        with torch.no_grad():
+            _, flow_up = model(prev_t, cur_t, iters=20, test_mode=True)
+        flow_np = flow_up[0].permute(1,2,0).cpu().numpy().astype(np.float32)
+        flows.append(flow_np)
+        prev_t = cur_t
+    cap.release()
+    return np.stack(flows) if flows else np.empty((0,), np.float32)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ h5py
 jiwer
 numpy==1.26.4
 opencv-python==4.8.1.78
+git+https://github.com/princeton-vl/RAFT.git
 

--- a/track_lsa_4.py
+++ b/track_lsa_4.py
@@ -10,6 +10,7 @@ import h5py
 from tqdm import tqdm
 import mediapipe as mp
 from ultralytics import YOLO
+from optical_flow.raft_runner import compute_optical_flow
 
 
 def box_iou(a, b):
@@ -196,11 +197,13 @@ def procesar_videos(input_dir, output_file,
                 prev_boxes,prev_ids,prev_centers = cur_boxes,cur_ids,cur_centers.copy()
 
             pbar.close(); cap.release()
+            flow_seq = compute_optical_flow(os.path.join(input_dir, vid))
             grp=h5f.create_group(vid)
             grp.create_dataset('pose',data=np.stack(pose_seq),compression='gzip')
             grp.create_dataset('left_hand',data=np.stack(lh_seq),compression='gzip')
             grp.create_dataset('right_hand',data=np.stack(rh_seq),compression='gzip')
             grp.create_dataset('face',data=np.stack(face_seq),compression='gzip')
+            grp.create_dataset('optical_flow',data=flow_seq,compression='gzip')
 
     holistic.close()
     if show_window: cv2.destroyAllWindows()


### PR DESCRIPTION
## Summary
- integrate a new RAFT-based optical flow module
- store optical flow results in the HDF5 output
- add RAFT dependency

## Testing
- `python -m py_compile track_lsa_4.py optical_flow/raft_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_6885513e801083319ac1566e91095441