### PR TITLE
Fix CSV parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Cada clip se enriquece con:
 * **Glosas** sincronizadas (`start`, `end`) para entrenamiento con CTC .
 * **Marcadores no‑manuales** (expresiones faciales y movimientos de cabeza) etiquetados como tareas auxiliares .
 * **Referencias deícticas** y silencios pre/post (`prev_delta`, `post_delta`) parseados con `ast.literal_eval` para modelar transiciones discursivas .
+* Los metadatos se almacenan en `meta.csv`, un archivo CSV separado por punto y coma (`;`).
 
 ---
 

--- a/visualize_lsa2.py
+++ b/visualize_lsa2.py
@@ -31,7 +31,7 @@ except IOError:
 
 def visualize(video_dir, h5_path, csv_path, win_size, no_window=False):
     # Leer CSV y HDF5
-    df = pd.read_csv(csv_path)
+    df = pd.read_csv(csv_path, sep=';')
     if 'id' not in df.columns:
         raise ValueError("CSV debe contener columna 'id' con el nombre base de cada vídeo.")
     if 'splits' not in df.columns and not {'video','label','start','end'}.issubset(df.columns):


### PR DESCRIPTION
## Summary
- ensure `visualize_lsa2.py` loads `meta.csv` with `sep=';'`
- document that `meta.csv` is semicolon separated

## Testing
- `python3 -m py_compile visualize_lsa2.py`


------
https://chatgpt.com/codex/tasks/task_e_6885510660b48331b5adb1aa57bf5b01