### PR TITLE
Add STTN and CorrNet+ models with configurable training

### DIFF
--- a/models/corrnet.py
+++ b/models/corrnet.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from .stgcn import STGCN
+
+class CorrNet(nn.Module):
+    """Compute correlation maps between frames."""
+    def __init__(self, in_channels: int):
+        super().__init__()
+        self.scale = 1.0 / (in_channels ** 0.5)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, C, T, V)
+        n, c, t, v = x.shape
+        feat = x.view(n, c * v, t)
+        feat = feat - feat.mean(dim=2, keepdim=True)
+        corr = torch.bmm(feat.transpose(1, 2), feat) * self.scale
+        return corr / (c * v)
+
+
+class CorrNetPlus(nn.Module):
+    """ST-GCN encoder enhanced with temporal correlation attention."""
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int):
+        super().__init__()
+        self.corr = CorrNet(in_channels)
+        self.encoder = STGCN(in_channels, num_class, num_nodes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, C, T, V)
+        corr = self.corr(x)
+        weights = torch.softmax(corr, dim=-1)  # (N, T, T)
+        agg = torch.einsum('nts,ncsv->nctv', weights, x)
+        x = x + agg
+        return self.encoder(x)

--- a/models/sttn.py
+++ b/models/sttn.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn as nn
+
+class STTNBlock(nn.Module):
+    """Reduced Spatio-Temporal Transformer block."""
+    def __init__(self, dim: int, num_heads: int = 4):
+        super().__init__()
+        self.spatial_attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+        self.spatial_ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(dim * 2, dim),
+        )
+        self.temporal_attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+        self.temporal_ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(dim * 2, dim),
+        )
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, C, T, V)
+        n, c, t, v = x.shape
+        # Spatial attention: attend over joints for each frame
+        s = x.permute(0, 2, 3, 1).reshape(n * t, v, c)  # (N*T, V, C)
+        attn_s, _ = self.spatial_attn(s, s, s)
+        s = s + attn_s
+        s = s + self.spatial_ff(s)
+        s = s.reshape(n, t, v, c).permute(0, 3, 1, 2)  # (N, C, T, V)
+        # Temporal attention: attend over frames for each joint
+        tmp = s.permute(0, 3, 2, 1).reshape(n * v, t, c)  # (N*V, T, C)
+        attn_t, _ = self.temporal_attn(tmp, tmp, tmp)
+        tmp = tmp + attn_t
+        tmp = tmp + self.temporal_ff(tmp)
+        out = tmp.reshape(n, v, t, c).permute(0, 3, 2, 1)  # (N, C, T, V)
+        return self.relu(out)
+
+
+class STTN(nn.Module):
+    """Simplified Spatio-Temporal Transformer Network."""
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int, num_layers: int = 2, embed_dim: int = 128):
+        super().__init__()
+        self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
+        self.layers = nn.ModuleList([STTNBlock(embed_dim) for _ in range(num_layers)])
+        self.pool = nn.AdaptiveAvgPool2d((None, 1))
+        self.fc = nn.Linear(embed_dim, num_class)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, C, T, V)
+        x = self.input_proj(x)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.pool(x)  # (N, C, T, 1)
+        x = x.squeeze(-1).permute(0, 2, 1)  # (N, T, C)
+        x = self.fc(x)
+        return x.log_softmax(-1)


### PR DESCRIPTION
## Summary
- implement a reduced Spatio‑Temporal Transformer Network (STTN)
- implement CorrNet and CorrNetPlus for temporal correlation attention
- support choosing model architecture in `train.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688556af34ec8331ac5764d82724ea22