### PR TITLE
Add adversarial training and active learning utilities

### DIFF
--- a/active_learning.py
+++ b/active_learning.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Selecciona ejemplos de baja confianza para reentrenamiento."""
+import os
+import argparse
+import h5py
+import torch
+from torch.utils.data import DataLoader
+from typing import List, Tuple
+
+from train import SignDataset, collate, build_model
+
+
+def compute_scores(model: torch.nn.Module, loader: DataLoader) -> List[Tuple[str, float]]:
+    device = next(model.parameters()).device
+    scores = []
+    model.eval()
+    with torch.no_grad():
+        for idx, (feats, labels, feat_lens, label_lens) in enumerate(loader):
+            feats = feats.to(device)
+            out = model(feats)
+            conf = out.exp().max(-1).values.mean().item()
+            vid = loader.dataset.samples[idx][0]
+            scores.append((vid, conf))
+    return scores
+
+
+def save_selected(scores: List[Tuple[str, float]], dataset: SignDataset, out_dir: str, top_k: int = 10) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    out_h5 = h5py.File(os.path.join(out_dir, "selected.h5"), "w")
+    csv_lines = []
+    for vid, _ in sorted(scores, key=lambda x: x[1])[:top_k]:
+        lbl = next(s[1] for s in dataset.samples if s[0] == vid)
+        grp = dataset.h5[vid]
+        new_grp = out_h5.create_group(vid)
+        for k in grp.keys():
+            new_grp.create_dataset(k, data=grp[k][()])
+        csv_lines.append(f"{os.path.splitext(vid)[0]};{lbl}")
+    with open(os.path.join(out_dir, "selected.csv"), "w", encoding="utf-8") as f:
+        for line in csv_lines:
+            f.write(line + "\n")
+    out_h5.close()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Proceso simple de active learning")
+    p.add_argument("--checkpoint", required=True, help="Modelo entrenado")
+    p.add_argument("--h5_file", required=True)
+    p.add_argument("--csv_file", required=True)
+    p.add_argument("--out_dir", required=True)
+    p.add_argument("--top_k", type=int, default=10, help="Cantidad de ejemplos a seleccionar")
+    args = p.parse_args()
+
+    ds = SignDataset(args.h5_file, args.csv_file)
+    dl = DataLoader(ds, batch_size=1, shuffle=False, collate_fn=collate)
+
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    if isinstance(ckpt, dict):
+        model = build_model("stgcn", len(ds.vocab))
+        model.load_state_dict(ckpt["model_state"])
+    else:
+        model = ckpt
+    model.eval()
+
+    scores = compute_scores(model, dl)
+    save_selected(scores, ds, args.out_dir, args.top_k)
+
+
+if __name__ == "__main__":
+    main()

--- a/dann.py
+++ b/dann.py
@@ -1,0 +1,31 @@
+import torch
+from torch import nn
+
+class GradReverse(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, lambd=1.0):
+        ctx.lambd = lambd
+        return x.view_as(x)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output.neg() * ctx.lambd, None
+
+
+def grad_reverse(x, lambd=1.0):
+    return GradReverse.apply(x, lambd)
+
+
+class DomainDiscriminator(nn.Module):
+    """Peque\u00f1o clasificador para distinguir dominios."""
+
+    def __init__(self, in_features: int, num_domains: int = 2, hidden_dim: int = 128):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(in_features, hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden_dim, num_domains),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)

--- a/models/corrnet.py
+++ b/models/corrnet.py
@@ -24,10 +24,10 @@ class CorrNetPlus(nn.Module):
         self.corr = CorrNet(in_channels)
         self.encoder = STGCN(in_channels, num_class, num_nodes)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
         corr = self.corr(x)
         weights = torch.softmax(corr, dim=-1)  # (N, T, T)
         agg = torch.einsum('nts,ncsv->nctv', weights, x)
         x = x + agg
-        return self.encoder(x)
+        return self.encoder(x, return_features=return_features)

--- a/models/sttn.py
+++ b/models/sttn.py
@@ -46,12 +46,15 @@ class STTN(nn.Module):
         self.pool = nn.AdaptiveAvgPool2d((None, 1))
         self.fc = nn.Linear(embed_dim, num_class)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
         x = self.input_proj(x)
         for layer in self.layers:
             x = layer(x)
         x = self.pool(x)  # (N, C, T, 1)
-        x = x.squeeze(-1).permute(0, 2, 1)  # (N, T, C)
-        x = self.fc(x)
-        return x.log_softmax(-1)
+        feat = x.squeeze(-1).permute(0, 2, 1)  # (N, T, C)
+        out = self.fc(feat)
+        log_probs = out.log_softmax(-1)
+        if return_features:
+            return log_probs, feat
+        return log_probs


### PR DESCRIPTION
## Summary
- implement `dann.py` with gradient reversal and domain discriminator
- extend `train.py` to accept `--domain_labels` and perform DANN training
- expose feature tensors in STGCN, STTN and CorrNet+ models
- add `active_learning.py` to collect low confidence samples for re-training

## Testing
- `python -m py_compile dann.py train.py active_learning.py models/stgcn.py models/sttn.py models/corrnet.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885577f915483318aec49d2f9f39521