### PR TITLE
Enable local RAFT checkpoint option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,9 @@ Se aplica **YOLOX** exportado a ONNX para extraer bounding boxes de la persona f
 
 * **MediaPipe Holistic** extrae **543 landmarks** (33 pose, 2×21 manos, 468 rostro) normalizados al torso para homogeneizar escala y perspectiva .
 * **RAFT** calcula flujo óptico denso focalizado en manos, capturando movimientos sutiles que complementan los landmarks .
+  Para ejecutar sin conexión debe descargarse el peso `raft-sintel.pth` desde
+  [RAFT](https://github.com/princeton-vl/RAFT/releases) y colocarse en
+  `checkpoints/` o indicar su ruta mediante la variable de entorno `RAFT_CKPT`.
 
 ### 2.4 Construcción de Grafos Esqueléticos
 

--- a/optical_flow/raft_runner.py
+++ b/optical_flow/raft_runner.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import torch
 import cv2
 import numpy as np
@@ -8,7 +11,15 @@ _device = 'cuda' if torch.cuda.is_available() else 'cpu'
 def _load_model():
     global _model
     if _model is None:
-        _model = torch.hub.load('princeton-vl/RAFT', 'raft', pretrained=True)
+        ckpt = os.environ.get("RAFT_CKPT")
+        if ckpt is None:
+            default_path = Path(__file__).resolve().parent.parent / "checkpoints" / "raft-sintel.pth"
+            if default_path.exists():
+                ckpt = str(default_path)
+        if ckpt is not None:
+            _model = torch.hub.load('princeton-vl/RAFT', 'raft', pretrained=False, ckpt=ckpt)
+        else:
+            _model = torch.hub.load('princeton-vl/RAFT', 'raft', pretrained=True)
         _model = _model.to(_device)
         _model.eval()
     return _model


### PR DESCRIPTION
## Summary
- allow RAFT optical flow runner to load a local checkpoint via the `RAFT_CKPT` environment variable or `checkpoints/raft-sintel.pth`
- document how to obtain the RAFT weights

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68856202d6c88331b8f1d245058ee582