### PR TITLE
Add SHuBERT self-supervised pretraining

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+from .stgcn import STGCN
+from .sttn import STTN
+from .corrnet import CorrNetPlus
+from .shubert import SHuBERT
+__all__ = ["STGCN", "STTN", "CorrNetPlus", "SHuBERT"]

--- a/models/shubert.py
+++ b/models/shubert.py
@@ -1,0 +1,53 @@
+import numpy as np
+import torch
+import torch.nn as nn
+from .stgcn import STGCNBlock
+
+class SHuBERT(nn.Module):
+    """Simple self-supervised model that masks landmark and optical-flow streams."""
+
+    def __init__(self, in_channels: int = 3, hidden_dim: int = 64, num_nodes: int = 544):
+        super().__init__()
+        A = np.eye(num_nodes, dtype=np.float32)
+        self.data_bn = nn.BatchNorm1d(num_nodes * in_channels)
+        self.layer1 = STGCNBlock(in_channels, hidden_dim, A)
+        self.layer2 = STGCNBlock(hidden_dim, hidden_dim, A)
+        self.layer3 = STGCNBlock(hidden_dim, hidden_dim, A)
+        self.project = nn.Conv2d(hidden_dim, in_channels, kernel_size=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        landmark_mask: torch.Tensor | None = None,
+        flow_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward pass with optional masks.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input sequence ``(N, C, T, V)``.
+        landmark_mask : torch.Tensor | None
+            Boolean mask ``(N, T)`` for landmark nodes.
+        flow_mask : torch.Tensor | None
+            Boolean mask ``(N, T)`` for the optical-flow node.
+        Returns
+        -------
+        torch.Tensor
+            Reconstructed features with the same shape as ``x``.
+        """
+        n, c, t, v = x.shape
+        if landmark_mask is not None:
+            m = landmark_mask[:, None, :, None]
+            x[:, :, :, :-1] = x[:, :, :, :-1] * (~m)
+        if flow_mask is not None:
+            m = flow_mask[:, None, :, None]
+            x[:, :, :, -1:] = x[:, :, :, -1:] * (~m)
+        x = x.permute(0, 3, 1, 2).contiguous().view(n, v * c, t)
+        x = self.data_bn(x)
+        x = x.view(n, v, c, t).permute(0, 2, 3, 1)
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        out = self.project(x)
+        return out

--- a/pretrain_shubert.py
+++ b/pretrain_shubert.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+import argparse
+import os
+import h5py
+import numpy as np
+import torch
+from torch.utils.data import Dataset, DataLoader
+from models.shubert import SHuBERT
+
+class RawH5Dataset(Dataset):
+    """Load sequences of landmarks and optical flow from an HDF5 file."""
+    def __init__(self, h5_path: str):
+        self.h5 = h5py.File(h5_path, 'r')
+        self.keys = list(self.h5.keys())
+
+    def __len__(self) -> int:
+        return len(self.keys)
+
+    def __getitem__(self, idx: int):
+        g = self.h5[self.keys[idx]]
+        pose = g['pose'][:].reshape(-1, 33, 3)
+        lh = g['left_hand'][:].reshape(-1, 21, 3)
+        rh = g['right_hand'][:].reshape(-1, 21, 3)
+        face = g['face'][:].reshape(-1, 468, 3)
+        flow = g['optical_flow'][:]
+        avg_flow = flow.mean(axis=(1,2))
+        mag = np.linalg.norm(avg_flow, axis=-1, keepdims=True)
+        flow_node = np.concatenate([avg_flow, mag], axis=1)
+        nodes = np.concatenate([pose, lh, rh, face, flow_node[:, None, :]], axis=1)
+        x = torch.from_numpy(nodes).permute(2,0,1).float()  # (C,T,V)
+        return x
+
+def collate_pretrain(batch):
+    C, V = batch[0].shape[0], batch[0].shape[2]
+    T = max(x.shape[1] for x in batch)
+    padded = []
+    lengths = []
+    for x in batch:
+        lengths.append(x.shape[1])
+        if x.shape[1] < T:
+            pad = torch.zeros(C, T - x.shape[1], V)
+            x = torch.cat([x, pad], dim=1)
+        padded.append(x)
+    return torch.stack(padded), torch.tensor(lengths)
+
+def train(args):
+    ds = RawH5Dataset(args.h5_file)
+    dl = DataLoader(ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_pretrain)
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = SHuBERT(num_nodes=544)
+    model.to(device)
+    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+    os.makedirs('checkpoints', exist_ok=True)
+
+    for epoch in range(args.epochs):
+        model.train()
+        total_loss = 0.0
+        for feats, lengths in dl:
+            feats = feats.to(device)
+            B, C, T, V = feats.shape
+            lm_mask = torch.rand(B, T, device=device) < args.mask_prob
+            flow_mask = torch.rand(B, T, device=device) < args.mask_prob
+            out = model(feats.clone(), lm_mask, flow_mask)
+            mse = (out - feats) ** 2
+            lm_loss = mse[:,:,:,:-1] * lm_mask[:,None,:,None]
+            flow_loss = mse[:,:,:,-1:] * flow_mask[:,None,:,None]
+            loss = (lm_loss.sum() / lm_mask.sum().clamp(min=1)) + (flow_loss.sum() / flow_mask.sum().clamp(min=1))
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+            total_loss += loss.item()
+        avg = total_loss / len(dl)
+        print(f"Epoch {epoch+1}: loss {avg:.4f}")
+        torch.save(model.state_dict(), f'checkpoints/shubert_epoch{epoch+1}.pt')
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description='Pretrain SHuBERT with self-supervised masking')
+    p.add_argument('--h5_file', required=True)
+    p.add_argument('--epochs', type=int, default=10)
+    p.add_argument('--batch_size', type=int, default=8)
+    p.add_argument('--mask_prob', type=float, default=0.15)
+    args = p.parse_args()
+    train(args)


### PR DESCRIPTION
## Summary
- implement `SHuBERT` model for masked landmark and optical‑flow reconstruction
- provide `pretrain_shubert.py` script to pretrain from raw HDF5 datasets
- expose `SHuBERT` in `models/__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6885766661048331b5dd05d6de1932d8