### PR TITLE
Add MCST transformer model

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,4 +2,6 @@ from .stgcn import STGCN
 from .sttn import STTN
 from .corrnet import CorrNetPlus
 from .shubert import SHuBERT
-__all__ = ["STGCN", "STTN", "CorrNetPlus", "SHuBERT"]
+from .mcst_transformer import MCSTTransformer
+
+__all__ = ["STGCN", "STTN", "CorrNetPlus", "SHuBERT", "MCSTTransformer"]

--- a/models/mcst_transformer.py
+++ b/models/mcst_transformer.py
@@ -1,0 +1,75 @@
+import torch
+import torch.nn as nn
+
+
+class MCSTBlock(nn.Module):
+    """Spatio-temporal block with multi-scale temporal attention."""
+
+    def __init__(self, dim: int, num_heads: int = 4, kernels: tuple[int, ...] = (3, 5, 7)):
+        super().__init__()
+        self.spatial_attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+        self.spatial_ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(dim * 2, dim),
+        )
+        self.temporal_attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+        self.temporal_ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(dim * 2, dim),
+        )
+        self.q_convs = nn.ModuleList([nn.Conv1d(dim, dim, k, padding=k // 2) for k in kernels])
+        self.k_convs = nn.ModuleList([nn.Conv1d(dim, dim, k, padding=k // 2) for k in kernels])
+        self.v_convs = nn.ModuleList([nn.Conv1d(dim, dim, k, padding=k // 2) for k in kernels])
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, C, T, V)
+        n, c, t, v = x.shape
+        # Spatial attention
+        s = x.permute(0, 2, 3, 1).reshape(n * t, v, c)
+        attn_s, _ = self.spatial_attn(s, s, s)
+        s = s + attn_s
+        s = s + self.spatial_ff(s)
+        s = s.reshape(n, t, v, c).permute(0, 3, 1, 2)
+        # Temporal multi-scale attention
+        tmp = s.permute(0, 3, 2, 1).reshape(n * v, t, c)
+        base = tmp
+        tmp_feat = tmp.transpose(1, 2)  # (N*V, C, T)
+        outs = []
+        for q_conv, k_conv, v_conv in zip(self.q_convs, self.k_convs, self.v_convs):
+            q = q_conv(tmp_feat).transpose(1, 2)
+            k = k_conv(tmp_feat).transpose(1, 2)
+            v_ = v_conv(tmp_feat).transpose(1, 2)
+            o, _ = self.temporal_attn(q, k, v_)
+            outs.append(o)
+        attn_t = sum(outs) / len(outs)
+        tmp = base + attn_t
+        tmp = tmp + self.temporal_ff(tmp)
+        out = tmp.reshape(n, v, t, c).permute(0, 3, 2, 1)
+        return self.relu(out)
+
+
+class MCSTTransformer(nn.Module):
+    """Multi-Scale Channel Spatio-Temporal Transformer."""
+
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int, num_layers: int = 2, embed_dim: int = 128):
+        super().__init__()
+        self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
+        self.layers = nn.ModuleList([MCSTBlock(embed_dim) for _ in range(num_layers)])
+        self.pool = nn.AdaptiveAvgPool2d((None, 1))
+        self.fc = nn.Linear(embed_dim, num_class)
+
+    def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
+        # x: (N, C, T, V)
+        x = self.input_proj(x)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.pool(x)  # (N, C, T, 1)
+        feat = x.squeeze(-1).permute(0, 2, 1)
+        out = self.fc(feat)
+        log_probs = out.log_softmax(-1)
+        if return_features:
+            return log_probs, feat
+        return log_probs

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,3 +19,7 @@ def test_sttn_forward():
 
 def test_corrnet_forward():
     _run_forward("corrnet+")
+
+
+def test_mcst_forward():
+    _run_forward("mcst")

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ from torch.utils.data import Dataset, DataLoader
 from models.stgcn import STGCN
 from models.sttn import STTN
 from models.corrnet import CorrNetPlus
+from models.mcst_transformer import MCSTTransformer
 
 class SignDataset(Dataset):
     def __init__(self, h5_path, csv_path, domain_csv=None):
@@ -105,6 +106,8 @@ def build_model(name: str, num_classes: int) -> nn.Module:
         return STTN(in_channels=3, num_class=num_classes, num_nodes=544)
     if name == 'corrnet+':
         return CorrNetPlus(in_channels=3, num_class=num_classes, num_nodes=544)
+    if name == 'mcst':
+        return MCSTTransformer(in_channels=3, num_class=num_classes, num_nodes=544)
     raise ValueError(f'Unknown model: {name}')
 
 
@@ -177,7 +180,7 @@ if __name__ == '__main__':
     p.add_argument('--csv_file', required=True, help='CSV file with transcripts')
     p.add_argument('--epochs', type=int, default=10)
     p.add_argument('--batch_size', type=int, default=4)
-    p.add_argument('--model', type=str, default='stgcn', choices=['stgcn', 'sttn', 'corrnet+'], help='Model architecture')
+    p.add_argument('--model', type=str, default='stgcn', choices=['stgcn', 'sttn', 'corrnet+', 'mcst'], help='Model architecture')
     p.add_argument('--domain_labels', help='CSV con etiquetas de dominio opcional')
     args = p.parse_args()
     train(args)


### PR DESCRIPTION
## Summary
- implement new MCSTTransformer with multi-scale temporal attention
- export the new model in `models/__init__.py`
- allow `--model mcst` option in `train.py`
- test forward pass for the new architecture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68857996cd808331a775f0551e4e27cb