### PR TITLE
Add multitask heads with dataset updates

### DIFF
--- a/models/corrnet.py
+++ b/models/corrnet.py
@@ -19,10 +19,12 @@ class CorrNet(nn.Module):
 
 class CorrNetPlus(nn.Module):
     """ST-GCN encoder enhanced with temporal correlation attention."""
-    def __init__(self, in_channels: int, num_class: int, num_nodes: int):
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int,
+                 num_nmm: int = 0, num_suffix: int = 0):
         super().__init__()
         self.corr = CorrNet(in_channels)
-        self.encoder = STGCN(in_channels, num_class, num_nodes)
+        self.encoder = STGCN(in_channels, num_class, num_nodes,
+                             num_nmm=num_nmm, num_suffix=num_suffix)
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)

--- a/models/mcst_transformer.py
+++ b/models/mcst_transformer.py
@@ -52,14 +52,18 @@ class MCSTBlock(nn.Module):
 
 
 class MCSTTransformer(nn.Module):
-    """Multi-Scale Channel Spatio-Temporal Transformer."""
+    """Multi-Scale Channel Spatio-Temporal Transformer with multitask heads."""
 
-    def __init__(self, in_channels: int, num_class: int, num_nodes: int, num_layers: int = 2, embed_dim: int = 128):
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int,
+                 num_layers: int = 2, embed_dim: int = 128,
+                 num_nmm: int = 0, num_suffix: int = 0):
         super().__init__()
         self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
         self.layers = nn.ModuleList([MCSTBlock(embed_dim) for _ in range(num_layers)])
         self.pool = nn.AdaptiveAvgPool2d((None, 1))
-        self.fc = nn.Linear(embed_dim, num_class)
+        self.ctc_head = nn.Linear(embed_dim, num_class)
+        self.nmm_head = nn.Linear(embed_dim, num_nmm) if num_nmm > 0 else None
+        self.suffix_head = nn.Linear(embed_dim, num_suffix) if num_suffix > 0 else None
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
@@ -68,8 +72,11 @@ class MCSTTransformer(nn.Module):
             x = layer(x)
         x = self.pool(x)  # (N, C, T, 1)
         feat = x.squeeze(-1).permute(0, 2, 1)
-        out = self.fc(feat)
-        log_probs = out.log_softmax(-1)
+        gloss = self.ctc_head(feat).log_softmax(-1)
+        pooled = feat.mean(dim=1)
+        nmm = self.nmm_head(pooled) if self.nmm_head else None
+        suffix = self.suffix_head(pooled) if self.suffix_head else None
+        outputs = (gloss, nmm, suffix)
         if return_features:
-            return log_probs, feat
-        return log_probs
+            return outputs, feat
+        return outputs

--- a/models/sttn.py
+++ b/models/sttn.py
@@ -38,13 +38,17 @@ class STTNBlock(nn.Module):
 
 
 class STTN(nn.Module):
-    """Simplified Spatio-Temporal Transformer Network."""
-    def __init__(self, in_channels: int, num_class: int, num_nodes: int, num_layers: int = 2, embed_dim: int = 128):
+    """Simplified Spatio-Temporal Transformer Network with multitask heads."""
+    def __init__(self, in_channels: int, num_class: int, num_nodes: int,
+                 num_layers: int = 2, embed_dim: int = 128,
+                 num_nmm: int = 0, num_suffix: int = 0):
         super().__init__()
         self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
         self.layers = nn.ModuleList([STTNBlock(embed_dim) for _ in range(num_layers)])
         self.pool = nn.AdaptiveAvgPool2d((None, 1))
-        self.fc = nn.Linear(embed_dim, num_class)
+        self.ctc_head = nn.Linear(embed_dim, num_class)
+        self.nmm_head = nn.Linear(embed_dim, num_nmm) if num_nmm > 0 else None
+        self.suffix_head = nn.Linear(embed_dim, num_suffix) if num_suffix > 0 else None
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
@@ -53,8 +57,11 @@ class STTN(nn.Module):
             x = layer(x)
         x = self.pool(x)  # (N, C, T, 1)
         feat = x.squeeze(-1).permute(0, 2, 1)  # (N, T, C)
-        out = self.fc(feat)
-        log_probs = out.log_softmax(-1)
+        gloss = self.ctc_head(feat).log_softmax(-1)
+        pooled = feat.mean(dim=1)
+        nmm = self.nmm_head(pooled) if self.nmm_head else None
+        suffix = self.suffix_head(pooled) if self.suffix_head else None
+        outputs = (gloss, nmm, suffix)
         if return_features:
-            return log_probs, feat
-        return log_probs
+            return outputs, feat
+        return outputs

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -13,7 +13,12 @@ def _create_data(h5_path, csv_path):
         grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
         grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
         grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
-    pd.DataFrame({"id": ["sample"], "label": ["hello world"]}).to_csv(csv_path, sep=";", index=False)
+    pd.DataFrame({
+        "id": ["sample"],
+        "label": ["hello world"],
+        "nmm": ["neutral"],
+        "suffix": ["none"],
+    }).to_csv(csv_path, sep=";", index=False)
 
 
 def test_dataset_loading(tmp_path):
@@ -22,10 +27,12 @@ def test_dataset_loading(tmp_path):
     _create_data(h5_file, csv_file)
     ds = SignDataset(str(h5_file), str(csv_file))
     assert len(ds) == 1
-    x, y, d = ds[0]
+    x, y, d, nmm, suf = ds[0]
     assert x.shape == (3, 2, 544)
     assert d == 0
     assert y.tolist() == [ds.vocab["hello"], ds.vocab["world"]]
+    assert nmm == ds.nmm_vocab["neutral"]
+    assert suf == ds.suffix_vocab["none"]
 
 
 def test_collate(tmp_path):
@@ -34,8 +41,10 @@ def test_collate(tmp_path):
     _create_data(h5_file, csv_file)
     ds = SignDataset(str(h5_file), str(csv_file))
     batch = [ds[0], ds[0]]
-    feats, labels, feat_lens, label_lens, domains = collate(batch)
+    feats, labels, feat_lens, label_lens, domains, nmms, sufs = collate(batch)
     assert feats.shape[0] == 2
     assert feat_lens.tolist() == [2, 2]
     assert label_lens.tolist() == [2, 2]
     assert domains.tolist() == [0, 0]
+    assert (nmms == ds.nmm_vocab["neutral"]).all()
+    assert (sufs == ds.suffix_vocab["none"]).all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,10 +3,12 @@ from train import build_model
 
 
 def _run_forward(name: str):
-    model = build_model(name, num_classes=5)
+    model = build_model(name, num_classes=5, num_nmm=2, num_suffix=3)
     inp = torch.randn(2, 3, 4, 544)
-    out = model(inp)
-    assert out.shape == (2, 4, 5)
+    gloss, nmm, suf = model(inp)
+    assert gloss.shape == (2, 4, 5)
+    assert nmm.shape == (2, 2)
+    assert suf.shape == (2, 3)
 
 
 def test_stgcn_forward():


### PR DESCRIPTION
## Summary
- extend models with CTC, non‑manual and suffix heads
- load non‑manual and suffix labels from `meta.csv`
- collate extra labels and compute new losses
- adjust dataset and model tests for new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68857b210c1c8331ab4db447165a1ebc