### PR TITLE
Enable LM beam search in server

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -22,6 +22,8 @@ import uuid
 import time
 
 from metrics import MetricsLogger
+from infer import beam_search
+from models.transformer_lm import load_model
 
 # Optional OpenFace binary
 OPENFACE_BIN = os.environ.get("OPENFACE_BIN")
@@ -85,11 +87,19 @@ except FileNotFoundError:
 SOS_TOKEN = 1
 EOS_TOKEN = 2
 
+# Optional language model and beam-search params
+LM_CKPT = os.environ.get("LM_CKPT")
+BEAM_SIZE = int(os.environ.get("BEAM_SIZE", "5"))
+LM_WEIGHT = float(os.environ.get("LM_WEIGHT", "0.5"))
+lm_model = None
+if LM_CKPT:
+    try:
+        lm_model = load_model(LM_CKPT, vocab_size=len(vocab))
+    except Exception:
+        lm_model = None
+
 def decode(logits: torch.Tensor) -> str:
-    if logits.dim() == 3:
-        tokens = logits.argmax(dim=-1)[0]
-    else:
-        tokens = logits.argmax(dim=-1)
+    tokens = beam_search(logits, lm_model, BEAM_SIZE, LM_WEIGHT, SOS_TOKEN, EOS_TOKEN)
     words = [vocab.get(int(t), "<unk>") for t in tokens if int(t) not in (SOS_TOKEN, EOS_TOKEN)]
     return " ".join(words)
 


### PR DESCRIPTION
## Summary
- use `beam_search` from `infer` instead of `argmax` decoding
- allow optional Transformer LM via `LM_CKPT`
- configure beam width and LM weight with `BEAM_SIZE` and `LM_WEIGHT`

## Testing
- `python -m py_compile server/app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6885906305a8833183376eb8dab32472