### PR TITLE
Fix compute_scores for new collate output

### DIFF
--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pandas as pd
+import h5py
+import torch
+from torch.utils.data import DataLoader
+
+from train import SignDataset, collate
+from active_learning import compute_scores
+
+
+def _create_data(h5_path, csv_path):
+    with h5py.File(h5_path, "w") as h5:
+        grp = h5.create_group("sample.mp4")
+        T = 2
+        grp.create_dataset("pose", data=np.zeros((T, 33 * 3), np.float32))
+        grp.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
+        grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
+        grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
+        grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
+    pd.DataFrame({
+        "id": ["sample"],
+        "label": ["hello world"],
+        "nmm": ["neutral"],
+        "suffix": ["none"],
+    }).to_csv(csv_path, sep=";", index=False)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, num_classes):
+        super().__init__()
+        self.num_classes = num_classes
+
+    def forward(self, x):
+        B, C, T, V = x.shape
+        logits = torch.zeros(B, T, self.num_classes)
+        # return tuple to mimic real model
+        return logits.log_softmax(-1), torch.empty(B, 2), torch.empty(B, 3)
+
+
+def test_compute_scores_with_collate(tmp_path):
+    h5_file = tmp_path / "data.h5"
+    csv_file = tmp_path / "labels.csv"
+    _create_data(h5_file, csv_file)
+
+    with SignDataset(str(h5_file), str(csv_file)) as ds:
+        dl = DataLoader(ds, batch_size=1, shuffle=False, collate_fn=collate)
+        model = DummyModel(len(ds.vocab))
+        scores = compute_scores(model, dl)
+
+    assert len(scores) == 1
+    assert scores[0][0] == "sample.mp4"
+    assert isinstance(scores[0][1], float)


### PR DESCRIPTION
## Summary
- unpack seven values from `collate` when computing scores
- handle models that return multiple tensors when calculating confidence
- add unit test covering `compute_scores` with the new collate output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and torch)*

------
https://chatgpt.com/codex/tasks/task_e_6885913231608331a4f267f2e3927ae9