### PR TITLE
Add RNM head support

### DIFF
--- a/active_learning.py
+++ b/active_learning.py
@@ -17,9 +17,10 @@ def compute_scores(model: torch.nn.Module, loader: DataLoader) -> List[Tuple[str
     scores = []
     model.eval()
     with torch.no_grad():
-        for idx, (feats, labels, feat_lens, label_lens) in enumerate(loader):
+        for idx, (feats, labels, feat_lens, label_lens, *_) in enumerate(loader):
             feats = feats.to(device)
-            out = model(feats)
+            gloss, *_ = model(feats)
+            out = gloss
             conf = out.exp().max(-1).values.mean().item()
             vid = loader.dataset.samples[idx][0]
             scores.append((vid, conf))

--- a/models/corrnet.py
+++ b/models/corrnet.py
@@ -20,11 +20,11 @@ class CorrNet(nn.Module):
 class CorrNetPlus(nn.Module):
     """ST-GCN encoder enhanced with temporal correlation attention."""
     def __init__(self, in_channels: int, num_class: int, num_nodes: int,
-                 num_nmm: int = 0, num_suffix: int = 0):
+                 num_nmm: int = 0, num_suffix: int = 0, num_rnm: int = 0):
         super().__init__()
         self.corr = CorrNet(in_channels)
         self.encoder = STGCN(in_channels, num_class, num_nodes,
-                             num_nmm=num_nmm, num_suffix=num_suffix)
+                             num_nmm=num_nmm, num_suffix=num_suffix, num_rnm=num_rnm)
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)

--- a/models/mcst_transformer.py
+++ b/models/mcst_transformer.py
@@ -56,7 +56,7 @@ class MCSTTransformer(nn.Module):
 
     def __init__(self, in_channels: int, num_class: int, num_nodes: int,
                  num_layers: int = 2, embed_dim: int = 128,
-                 num_nmm: int = 0, num_suffix: int = 0):
+                 num_nmm: int = 0, num_suffix: int = 0, num_rnm: int = 0):
         super().__init__()
         self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
         self.layers = nn.ModuleList([MCSTBlock(embed_dim) for _ in range(num_layers)])
@@ -64,6 +64,7 @@ class MCSTTransformer(nn.Module):
         self.ctc_head = nn.Linear(embed_dim, num_class)
         self.nmm_head = nn.Linear(embed_dim, num_nmm) if num_nmm > 0 else None
         self.suffix_head = nn.Linear(embed_dim, num_suffix) if num_suffix > 0 else None
+        self.rnm_head = nn.Linear(embed_dim, num_rnm) if num_rnm > 0 else None
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
@@ -76,7 +77,8 @@ class MCSTTransformer(nn.Module):
         pooled = feat.mean(dim=1)
         nmm = self.nmm_head(pooled) if self.nmm_head else None
         suffix = self.suffix_head(pooled) if self.suffix_head else None
-        outputs = (gloss, nmm, suffix)
+        rnm = self.rnm_head(pooled) if self.rnm_head else None
+        outputs = (gloss, nmm, suffix, rnm)
         if return_features:
             return outputs, feat
         return outputs

--- a/models/stgcn.py
+++ b/models/stgcn.py
@@ -39,7 +39,7 @@ class STGCNBlock(nn.Module):
 
 class STGCN(nn.Module):
     def __init__(self, in_channels, num_class, num_nodes, num_nmm: int = 0,
-                 num_suffix: int = 0):
+                 num_suffix: int = 0, num_rnm: int = 0):
         """Spatial Temporal GCN with optional multitask heads."""
         super().__init__()
         cfg_path = Path(__file__).resolve().parent.parent / "configs" / "skeleton.yaml"
@@ -59,6 +59,7 @@ class STGCN(nn.Module):
         self.ctc_head = nn.Linear(128, num_class)
         self.nmm_head = nn.Linear(128, num_nmm) if num_nmm > 0 else None
         self.suffix_head = nn.Linear(128, num_suffix) if num_suffix > 0 else None
+        self.rnm_head = nn.Linear(128, num_rnm) if num_rnm > 0 else None
 
     def forward(self, x, return_features: bool = False):
         """Propagaci\u00f3n forward con opci\u00f3n de extraer features."""
@@ -77,7 +78,8 @@ class STGCN(nn.Module):
         pooled = feat.mean(dim=1)
         nmm = self.nmm_head(pooled) if self.nmm_head else None
         suffix = self.suffix_head(pooled) if self.suffix_head else None
-        outputs = (gloss, nmm, suffix)
+        rnm = self.rnm_head(pooled) if self.rnm_head else None
+        outputs = (gloss, nmm, suffix, rnm)
         if return_features:
             return outputs, feat
         return outputs

--- a/models/sttn.py
+++ b/models/sttn.py
@@ -41,7 +41,7 @@ class STTN(nn.Module):
     """Simplified Spatio-Temporal Transformer Network with multitask heads."""
     def __init__(self, in_channels: int, num_class: int, num_nodes: int,
                  num_layers: int = 2, embed_dim: int = 128,
-                 num_nmm: int = 0, num_suffix: int = 0):
+                 num_nmm: int = 0, num_suffix: int = 0, num_rnm: int = 0):
         super().__init__()
         self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
         self.layers = nn.ModuleList([STTNBlock(embed_dim) for _ in range(num_layers)])
@@ -49,6 +49,7 @@ class STTN(nn.Module):
         self.ctc_head = nn.Linear(embed_dim, num_class)
         self.nmm_head = nn.Linear(embed_dim, num_nmm) if num_nmm > 0 else None
         self.suffix_head = nn.Linear(embed_dim, num_suffix) if num_suffix > 0 else None
+        self.rnm_head = nn.Linear(embed_dim, num_rnm) if num_rnm > 0 else None
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
@@ -61,7 +62,8 @@ class STTN(nn.Module):
         pooled = feat.mean(dim=1)
         nmm = self.nmm_head(pooled) if self.nmm_head else None
         suffix = self.suffix_head(pooled) if self.suffix_head else None
-        outputs = (gloss, nmm, suffix)
+        rnm = self.rnm_head(pooled) if self.rnm_head else None
+        outputs = (gloss, nmm, suffix, rnm)
         if return_features:
             return outputs, feat
         return outputs

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -18,6 +18,7 @@ def _create_data(h5_path, csv_path):
         "label": ["hello world"],
         "nmm": ["neutral"],
         "suffix": ["none"],
+        "rnm": ["r1"],
     }).to_csv(csv_path, sep=";", index=False)
 
 
@@ -27,12 +28,13 @@ def test_dataset_loading(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         assert len(ds) == 1
-        x, y, d, nmm, suf = ds[0]
+        x, y, d, nmm, suf, rnm = ds[0]
         assert x.shape == (3, 2, 544)
         assert d == 0
         assert y.tolist() == [ds.vocab["hello"], ds.vocab["world"]]
         assert nmm == ds.nmm_vocab["neutral"]
         assert suf == ds.suffix_vocab["none"]
+        assert rnm == ds.rnm_vocab["r1"]
 
 
 def test_collate(tmp_path):
@@ -41,10 +43,11 @@ def test_collate(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         batch = [ds[0], ds[0]]
-        feats, labels, feat_lens, label_lens, domains, nmms, sufs = collate(batch)
+        feats, labels, feat_lens, label_lens, domains, nmms, sufs, rnms = collate(batch)
         assert feats.shape[0] == 2
         assert feat_lens.tolist() == [2, 2]
         assert label_lens.tolist() == [2, 2]
         assert domains.tolist() == [0, 0]
         assert (nmms == ds.nmm_vocab["neutral"]).all()
         assert (sufs == ds.suffix_vocab["none"]).all()
+        assert (rnms == ds.rnm_vocab["r1"]).all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,12 +3,13 @@ from train import build_model
 
 
 def _run_forward(name: str):
-    model = build_model(name, num_classes=5, num_nmm=2, num_suffix=3)
+    model = build_model(name, num_classes=5, num_nmm=2, num_suffix=3, num_rnm=4)
     inp = torch.randn(2, 3, 4, 544)
-    gloss, nmm, suf = model(inp)
+    gloss, nmm, suf, rnm = model(inp)
     assert gloss.shape == (2, 4, 5)
     assert nmm.shape == (2, 2)
     assert suf.shape == (2, 3)
+    assert rnm.shape == (2, 4)
 
 
 def test_stgcn_forward():

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ class SignDataset(Dataset):
         label_map = {str(r['id']): str(r['label']) for _, r in df.iterrows()}
         nmm_map = {str(r['id']): str(r.get('nmm', 'none')) for _, r in df.iterrows()} if 'nmm' in df.columns else {}
         suf_map = {str(r['id']): str(r.get('suffix', 'none')) for _, r in df.iterrows()} if 'suffix' in df.columns else {}
+        rnm_map = {str(r['id']): str(r.get('rnm', 'none')) for _, r in df.iterrows()} if 'rnm' in df.columns else {}
         self.domain_map = {}
         if domain_csv:
             dom = pd.read_csv(domain_csv, sep=';')
@@ -33,10 +34,12 @@ class SignDataset(Dataset):
                 domain = self.domain_map.get(base, 0)
                 nmm = nmm_map.get(base, 'none') if nmm_map else 'none'
                 suf = suf_map.get(base, 'none') if suf_map else 'none'
-                self.samples.append((vid, label_map[base], domain, nmm, suf))
+                rnm = rnm_map.get(base, 'none') if rnm_map else 'none'
+                self.samples.append((vid, label_map[base], domain, nmm, suf, rnm))
         self.vocab = self._build_vocab()
         self.nmm_vocab = self._build_map([s[3] for s in self.samples])
         self.suffix_vocab = self._build_map([s[4] for s in self.samples])
+        self.rnm_vocab = self._build_map([s[5] for s in self.samples])
         self.num_domains = len(set(s[2] for s in self.samples)) or 1
 
     def close(self):
@@ -73,7 +76,7 @@ class SignDataset(Dataset):
         return len(self.samples)
 
     def __getitem__(self, idx):
-        vid, lbl, domain, nmm, suf = self.samples[idx]
+        vid, lbl, domain, nmm, suf, rnm = self.samples[idx]
         g = self.h5[vid]
         pose = g['pose'][:].reshape(-1, 33, 3)
         lh = g['left_hand'][:].reshape(-1, 21, 3)
@@ -90,11 +93,12 @@ class SignDataset(Dataset):
         y = torch.tensor(tokens, dtype=torch.long)
         nmm_id = self.nmm_vocab[nmm]
         suf_id = self.suffix_vocab[suf]
-        return x, y, domain, nmm_id, suf_id
+        rnm_id = self.rnm_vocab[rnm]
+        return x, y, domain, nmm_id, suf_id, rnm_id
 
 def collate(batch):
     """Pad secuencias y empaquetar dominios y labels auxiliares."""
-    feats, labels, domains, nmms, sufs = zip(*batch)
+    feats, labels, domains, nmms, sufs, rnms = zip(*batch)
     T = max(f.shape[1] for f in feats)
     V = feats[0].shape[2]
     C = feats[0].shape[0]
@@ -120,7 +124,8 @@ def collate(batch):
     doms = torch.tensor(domains, dtype=torch.long)
     nmm_t = torch.tensor(nmms, dtype=torch.long)
     suf_t = torch.tensor(sufs, dtype=torch.long)
-    return padded_feats, padded_labels, torch.tensor(feat_lengths), torch.tensor(label_lengths), doms, nmm_t, suf_t
+    rnm_t = torch.tensor(rnms, dtype=torch.long)
+    return padded_feats, padded_labels, torch.tensor(feat_lengths), torch.tensor(label_lengths), doms, nmm_t, suf_t, rnm_t
 
 def _contrastive(feats: torch.Tensor) -> torch.Tensor:
     """Simple NT-Xent style loss over batch-averaged features."""
@@ -130,20 +135,20 @@ def _contrastive(feats: torch.Tensor) -> torch.Tensor:
     labels = torch.arange(f.size(0), device=f.device)
     return nn.functional.cross_entropy(sim, labels)
 
-def build_model(name: str, num_classes: int, num_nmm: int = 0, num_suffix: int = 0) -> nn.Module:
+def build_model(name: str, num_classes: int, num_nmm: int = 0, num_suffix: int = 0, num_rnm: int = 0) -> nn.Module:
     """Create the selected model."""
     if name == 'stgcn':
         return STGCN(in_channels=3, num_class=num_classes, num_nodes=544,
-                     num_nmm=num_nmm, num_suffix=num_suffix)
+                     num_nmm=num_nmm, num_suffix=num_suffix, num_rnm=num_rnm)
     if name == 'sttn':
         return STTN(in_channels=3, num_class=num_classes, num_nodes=544,
-                    num_nmm=num_nmm, num_suffix=num_suffix)
+                    num_nmm=num_nmm, num_suffix=num_suffix, num_rnm=num_rnm)
     if name == 'corrnet+':
         return CorrNetPlus(in_channels=3, num_class=num_classes, num_nodes=544,
-                           num_nmm=num_nmm, num_suffix=num_suffix)
+                           num_nmm=num_nmm, num_suffix=num_suffix, num_rnm=num_rnm)
     if name == 'mcst':
         return MCSTTransformer(in_channels=3, num_class=num_classes, num_nodes=544,
-                               num_nmm=num_nmm, num_suffix=num_suffix)
+                               num_nmm=num_nmm, num_suffix=num_suffix, num_rnm=num_rnm)
     raise ValueError(f'Unknown model: {name}')
 
 
@@ -159,11 +164,11 @@ def evaluate(model: nn.Module, dl: DataLoader, inv_vocab: dict, device: torch.de
     correct_nmm = 0
     count_nmm = 0
     with torch.no_grad():
-        for feats, labels, feat_lens, label_lens, domains, nmm_lbls, _ in dl:
+        for feats, labels, feat_lens, label_lens, domains, nmm_lbls, suf_lbls, rnm_lbls in dl:
             feats = feats.to(device)
             labels = labels.to(device)
             nmm_lbls = nmm_lbls.to(device)
-            logits, nmm_logits, _ = model(feats)
+            logits, nmm_logits, _, _ = model(feats)
             preds = logits.argmax(-1)
             for p, t in zip(preds, labels):
                 pred_tokens = []
@@ -191,7 +196,7 @@ def train(args):
     with SignDataset(args.h5_file, args.csv_file, args.domain_labels) as ds:
         dl = DataLoader(ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate)
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        model = build_model(args.model, len(ds.vocab), len(ds.nmm_vocab), len(ds.suffix_vocab))
+        model = build_model(args.model, len(ds.vocab), len(ds.nmm_vocab), len(ds.suffix_vocab), len(ds.rnm_vocab))
         model.to(device)
         criterion = nn.CTCLoss(blank=0, zero_infinity=True)
         ce_loss = nn.CrossEntropyLoss()
@@ -213,19 +218,20 @@ def train(args):
             model.train()
             epoch_loss = 0.0
             for batch in dl:
-                feats, labels, feat_lens, label_lens, domains, nmm_lbls, suf_lbls = batch
+                feats, labels, feat_lens, label_lens, domains, nmm_lbls, suf_lbls, rnm_lbls = batch
                 domains = domains.to(device)
                 feats = feats.to(device)
                 labels = labels.to(device)
                 nmm_lbls = nmm_lbls.to(device)
                 suf_lbls = suf_lbls.to(device)
+                rnm_lbls = rnm_lbls.to(device)
                 feat_lens = feat_lens.to(device)
                 label_lens = label_lens.to(device)
                 return_feat = args.domain_labels or args.contrastive
                 if return_feat:
-                    (outputs, nmm_logits, suf_logits), feats_emb = model(feats, return_features=True)
+                    (outputs, nmm_logits, suf_logits, rnm_logits), feats_emb = model(feats, return_features=True)
                 else:
-                    outputs, nmm_logits, suf_logits = model(feats)
+                    outputs, nmm_logits, suf_logits, rnm_logits = model(feats)
                 outputs = outputs.permute(1, 0, 2)  # T,B,C
                 # nn.CTCLoss requiere que todas las etiquetas estén
                 # concatenadas en un solo vector y se pasen sus longitudes
@@ -237,6 +243,8 @@ def train(args):
                     loss = loss + ce_loss(nmm_logits, nmm_lbls)
                 if suf_logits is not None:
                     loss = loss + ce_loss(suf_logits, suf_lbls)
+                if rnm_logits is not None:
+                    loss = loss + ce_loss(rnm_logits, rnm_lbls)
                 if args.domain_labels:
                     dom_feat = feats_emb.mean(dim=1)
                     dom_logits = disc(grad_reverse(dom_feat))


### PR DESCRIPTION
## Summary
- extend `SignDataset` to load rnm labels and return them in `collate`
- add optional `rnm_head` to all models
- update training to handle rnm loss
- adjust evaluation and active learning utils for new outputs
- update dataset and model tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68859123e4788331a0e40dfb1e07a462