### PR TITLE
Add RNM head to models and training

### DIFF
--- a/active_learning.py
+++ b/active_learning.py
@@ -19,7 +19,7 @@ def compute_scores(model: torch.nn.Module, loader: DataLoader) -> List[Tuple[str
     model.eval()
     with torch.no_grad():
         for idx, batch in enumerate(loader):
-            # collate returns seven values; we only need the features
+            # collate returns eight values; we only need the features
             feats = batch[0].to(device)
 
             out = model(feats)

--- a/models/corrnet.py
+++ b/models/corrnet.py
@@ -19,12 +19,26 @@ class CorrNet(nn.Module):
 
 class CorrNetPlus(nn.Module):
     """ST-GCN encoder enhanced with temporal correlation attention."""
-    def __init__(self, in_channels: int, num_class: int, num_nodes: int,
-                 num_nmm: int = 0, num_suffix: int = 0):
+
+    def __init__(
+        self,
+        in_channels: int,
+        num_class: int,
+        num_nodes: int,
+        num_nmm: int = 0,
+        num_suffix: int = 0,
+        num_rnm: int = 0,
+    ):
         super().__init__()
         self.corr = CorrNet(in_channels)
-        self.encoder = STGCN(in_channels, num_class, num_nodes,
-                             num_nmm=num_nmm, num_suffix=num_suffix)
+        self.encoder = STGCN(
+            in_channels,
+            num_class,
+            num_nodes,
+            num_nmm=num_nmm,
+            num_suffix=num_suffix,
+            num_rnm=num_rnm,
+        )
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)

--- a/models/mcst_transformer.py
+++ b/models/mcst_transformer.py
@@ -54,9 +54,17 @@ class MCSTBlock(nn.Module):
 class MCSTTransformer(nn.Module):
     """Multi-Scale Channel Spatio-Temporal Transformer with multitask heads."""
 
-    def __init__(self, in_channels: int, num_class: int, num_nodes: int,
-                 num_layers: int = 2, embed_dim: int = 128,
-                 num_nmm: int = 0, num_suffix: int = 0):
+    def __init__(
+        self,
+        in_channels: int,
+        num_class: int,
+        num_nodes: int,
+        num_layers: int = 2,
+        embed_dim: int = 128,
+        num_nmm: int = 0,
+        num_suffix: int = 0,
+        num_rnm: int = 0,
+    ):
         super().__init__()
         self.input_proj = nn.Conv2d(in_channels, embed_dim, kernel_size=1)
         self.layers = nn.ModuleList([MCSTBlock(embed_dim) for _ in range(num_layers)])
@@ -64,6 +72,7 @@ class MCSTTransformer(nn.Module):
         self.ctc_head = nn.Linear(embed_dim, num_class)
         self.nmm_head = nn.Linear(embed_dim, num_nmm) if num_nmm > 0 else None
         self.suffix_head = nn.Linear(embed_dim, num_suffix) if num_suffix > 0 else None
+        self.rnm_head = nn.Linear(embed_dim, num_rnm) if num_rnm > 0 else None
 
     def forward(self, x: torch.Tensor, return_features: bool = False) -> torch.Tensor:
         # x: (N, C, T, V)
@@ -76,7 +85,8 @@ class MCSTTransformer(nn.Module):
         pooled = feat.mean(dim=1)
         nmm = self.nmm_head(pooled) if self.nmm_head else None
         suffix = self.suffix_head(pooled) if self.suffix_head else None
-        outputs = (gloss, nmm, suffix)
+        rnm = self.rnm_head(pooled) if self.rnm_head else None
+        outputs = (gloss, nmm, suffix, rnm)
         if return_features:
             return outputs, feat
         return outputs

--- a/models/stgcn.py
+++ b/models/stgcn.py
@@ -38,8 +38,15 @@ class STGCNBlock(nn.Module):
         return self.relu(x)
 
 class STGCN(nn.Module):
-    def __init__(self, in_channels, num_class, num_nodes, num_nmm: int = 0,
-                 num_suffix: int = 0):
+    def __init__(
+        self,
+        in_channels,
+        num_class,
+        num_nodes,
+        num_nmm: int = 0,
+        num_suffix: int = 0,
+        num_rnm: int = 0,
+    ):
         """Spatial Temporal GCN with optional multitask heads."""
         super().__init__()
         cfg_path = Path(__file__).resolve().parent.parent / "configs" / "skeleton.yaml"
@@ -59,6 +66,7 @@ class STGCN(nn.Module):
         self.ctc_head = nn.Linear(128, num_class)
         self.nmm_head = nn.Linear(128, num_nmm) if num_nmm > 0 else None
         self.suffix_head = nn.Linear(128, num_suffix) if num_suffix > 0 else None
+        self.rnm_head = nn.Linear(128, num_rnm) if num_rnm > 0 else None
 
     def forward(self, x, return_features: bool = False):
         """Propagaci\u00f3n forward con opci\u00f3n de extraer features."""
@@ -77,7 +85,8 @@ class STGCN(nn.Module):
         pooled = feat.mean(dim=1)
         nmm = self.nmm_head(pooled) if self.nmm_head else None
         suffix = self.suffix_head(pooled) if self.suffix_head else None
-        outputs = (gloss, nmm, suffix)
+        rnm = self.rnm_head(pooled) if self.rnm_head else None
+        outputs = (gloss, nmm, suffix, rnm)
         if return_features:
             return outputs, feat
         return outputs

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -22,6 +22,7 @@ def _create_data(h5_path, csv_path):
         "label": ["hello world"],
         "nmm": ["neutral"],
         "suffix": ["none"],
+        "rnm": ["tipo1"],
     }).to_csv(csv_path, sep=";", index=False)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -18,6 +18,7 @@ def _create_data(h5_path, csv_path):
         "label": ["hello world"],
         "nmm": ["neutral"],
         "suffix": ["none"],
+        "rnm": ["tipo1"],
     }).to_csv(csv_path, sep=";", index=False)
 
 
@@ -27,12 +28,13 @@ def test_dataset_loading(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         assert len(ds) == 1
-        x, y, d, nmm, suf = ds[0]
+        x, y, d, nmm, suf, rnm = ds[0]
         assert x.shape == (3, 2, 544)
         assert d == 0
         assert y.tolist() == [ds.vocab["hello"], ds.vocab["world"]]
         assert nmm == ds.nmm_vocab["neutral"]
         assert suf == ds.suffix_vocab["none"]
+        assert rnm == ds.rnm_vocab["tipo1"]
 
 
 def test_collate(tmp_path):
@@ -41,10 +43,11 @@ def test_collate(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         batch = [ds[0], ds[0]]
-        feats, labels, feat_lens, label_lens, domains, nmms, sufs = collate(batch)
+        feats, labels, feat_lens, label_lens, domains, nmms, sufs, rnms = collate(batch)
         assert feats.shape[0] == 2
         assert feat_lens.tolist() == [2, 2]
         assert label_lens.tolist() == [2, 2]
         assert domains.tolist() == [0, 0]
         assert (nmms == ds.nmm_vocab["neutral"]).all()
         assert (sufs == ds.suffix_vocab["none"]).all()
+        assert (rnms == ds.rnm_vocab["tipo1"]).all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,12 +3,13 @@ from train import build_model
 
 
 def _run_forward(name: str):
-    model = build_model(name, num_classes=5, num_nmm=2, num_suffix=3)
+    model = build_model(name, num_classes=5, num_nmm=2, num_suffix=3, num_rnm=4)
     inp = torch.randn(2, 3, 4, 544)
-    gloss, nmm, suf = model(inp)
+    gloss, nmm, suf, rnm = model(inp)
     assert gloss.shape == (2, 4, 5)
     assert nmm.shape == (2, 2)
     assert suf.shape == (2, 3)
+    assert rnm.shape == (2, 4)
 
 
 def test_stgcn_forward():


### PR DESCRIPTION
## Summary
- update dataset and collate to support RNM labels
- add rnm_head to STGCN, STTN and MCSTTransformer
- extend CorrNetPlus and build_model for RNM
- compute RNM cross entropy in train loop
- adjust active learning and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6885936012e88331887ef8b1c941fa49