### PR TITLE
Add morphological metadata handling

### DIFF
--- a/active_learning.py
+++ b/active_learning.py
@@ -19,7 +19,7 @@ def compute_scores(model: torch.nn.Module, loader: DataLoader) -> List[Tuple[str
     model.eval()
     with torch.no_grad():
         for idx, batch in enumerate(loader):
-            # collate returns eight values; we only need the features
+            # collate returns many values; the first element contains the features
             feats = batch[0].to(device)
 
             out = model(feats)

--- a/data/meta_generator.py
+++ b/data/meta_generator.py
@@ -1,0 +1,47 @@
+import argparse
+import pandas as pd
+from typing import Tuple
+
+try:
+    import spacy
+except Exception:  # pragma: no cover - optional dependency
+    spacy = None
+
+
+_DEF_MODEL = "es_core_news_sm"
+
+
+def _extract_morph(text: str, nlp) -> Tuple[str, str, str, str, str]:
+    if nlp is None:
+        return ("none",) * 5
+    doc = nlp(text)
+    for tok in doc:
+        if tok.pos_ == "VERB":
+            m = tok.morph
+            person = (m.get("Person") or ["none"])[0].lower()
+            number = (m.get("Number") or ["none"])[0].lower()
+            tense = (m.get("Tense") or ["none"])[0].lower()
+            aspect = (m.get("Aspect") or ["none"])[0].lower()
+            mood = (m.get("Mood") or ["none"])[0].lower()
+            return person, number, tense, aspect, mood
+    return ("none",) * 5
+
+
+def main(inp: str, out: str, model: str = _DEF_MODEL) -> None:
+    df = pd.read_csv(inp, sep=";")
+    nlp = spacy.load(model) if spacy else None
+    rows = [
+        _extract_morph(str(row["label"]), nlp)
+        for _, row in df.iterrows()
+    ]
+    df[["person", "number", "tense", "aspect", "mode"]] = rows
+    df.to_csv(out, sep=";", index=False)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Generate enriched metadata CSV")
+    p.add_argument("input_csv")
+    p.add_argument("output_csv")
+    p.add_argument("--model", default=_DEF_MODEL, help="spaCy model")
+    args = p.parse_args()
+    main(args.input_csv, args.output_csv, args.model)

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -23,6 +23,11 @@ def _create_data(h5_path, csv_path):
         "nmm": ["neutral"],
         "suffix": ["none"],
         "rnm": ["tipo1"],
+        "person": ["1"],
+        "number": ["sg"],
+        "tense": ["pres"],
+        "aspect": ["simple"],
+        "mode": ["ind"],
     }).to_csv(csv_path, sep=";", index=False)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -19,6 +19,11 @@ def _create_data(h5_path, csv_path):
         "nmm": ["neutral"],
         "suffix": ["none"],
         "rnm": ["tipo1"],
+        "person": ["1"],
+        "number": ["sg"],
+        "tense": ["pres"],
+        "aspect": ["simple"],
+        "mode": ["ind"],
     }).to_csv(csv_path, sep=";", index=False)
 
 
@@ -28,13 +33,18 @@ def test_dataset_loading(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         assert len(ds) == 1
-        x, y, d, nmm, suf, rnm = ds[0]
+        x, y, d, nmm, suf, rnm, per, num, tense, aspect, mode = ds[0]
         assert x.shape == (3, 2, 544)
         assert d == 0
         assert y.tolist() == [ds.vocab["hello"], ds.vocab["world"]]
         assert nmm == ds.nmm_vocab["neutral"]
         assert suf == ds.suffix_vocab["none"]
         assert rnm == ds.rnm_vocab["tipo1"]
+        assert per == ds.person_vocab["1"]
+        assert num == ds.number_vocab["sg"]
+        assert tense == ds.tense_vocab["pres"]
+        assert aspect == ds.aspect_vocab["simple"]
+        assert mode == ds.mode_vocab["ind"]
 
 
 def test_collate(tmp_path):
@@ -43,7 +53,21 @@ def test_collate(tmp_path):
     _create_data(h5_file, csv_file)
     with SignDataset(str(h5_file), str(csv_file)) as ds:
         batch = [ds[0], ds[0]]
-        feats, labels, feat_lens, label_lens, domains, nmms, sufs, rnms = collate(batch)
+        (
+            feats,
+            labels,
+            feat_lens,
+            label_lens,
+            domains,
+            nmms,
+            sufs,
+            rnms,
+            pers,
+            nums,
+            tenses,
+            aspects,
+            modes,
+        ) = collate(batch)
         assert feats.shape[0] == 2
         assert feat_lens.tolist() == [2, 2]
         assert label_lens.tolist() == [2, 2]
@@ -51,3 +75,8 @@ def test_collate(tmp_path):
         assert (nmms == ds.nmm_vocab["neutral"]).all()
         assert (sufs == ds.suffix_vocab["none"]).all()
         assert (rnms == ds.rnm_vocab["tipo1"]).all()
+        assert (pers == ds.person_vocab["1"]).all()
+        assert (nums == ds.number_vocab["sg"]).all()
+        assert (tenses == ds.tense_vocab["pres"]).all()
+        assert (aspects == ds.aspect_vocab["simple"]).all()
+        assert (modes == ds.mode_vocab["ind"]).all()


### PR DESCRIPTION
## Summary
- create `data/meta_generator.py` to build enriched metadata with verb morphology
- extend `SignDataset` with person/number/tense/aspect/mode fields
- pad these new labels in `collate`
- adjust training and active-learning utilities to ignore extra outputs
- update dataset tests accordingly

## Testing
- `python -m py_compile train.py active_learning.py tests/test_dataset.py tests/test_active_learning.py data/meta_generator.py`
- ❌ `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68863ab074388331934a17c6a0e3eff5