### PR TITLE
Add SOS/EOS tokens to vocabulary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,7 @@ Para realizar pruebas rápidas sin modelos entrenados, cree ficheros de relleno:
 ```
 mkdir -p checkpoints
 :>checkpoints/model.ts
-printf "<unk>\n<pad>\n" > vocab.txt
+printf "<blank>\n<sos>\n<eos>\n" > vocab.txt
 ```
 
 Si dispone de los pesos reales y un vocabulario entrenado, reemplace estos archivos por los originales.

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -1,0 +1,10 @@
+import torch
+from infer import beam_search
+
+
+def test_beam_search_basic():
+    logits = torch.tensor([[[0.0, 0.0, 0.0, 5.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 5.0],
+                            [0.0, 0.0, 5.0, 0.0, 0.0]]])
+    tokens = beam_search(logits, None, beam=2)
+    assert tokens == [1, 3, 4, 2]


### PR DESCRIPTION
## Summary
- reserve `<blank>`, `<sos>` and `<eos>` in dataset vocabulary
- ignore the new tokens during evaluation
- write vocabulary to `vocab.txt` when training finishes
- update README placeholder
- test `beam_search` with the new vocabulary

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886450e2bbc8331b20f7d7e05ea4560