### PR TITLE
Add optional OpenFace data

### DIFF
--- a/configs/skeleton.yaml
+++ b/configs/skeleton.yaml
@@ -69,3 +69,12 @@ face:
 flow:
   count: 1
   connections: []
+head_pose:
+  count: 1
+  connections: []
+torso_pose:
+  count: 1
+  connections: []
+aus:
+  count: 17
+  connections: []

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -38,11 +38,27 @@ def _create_segment_data(h5_path, csv_path):
             seg.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
             seg.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
             seg.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
-            seg.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
+        seg.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
     pd.DataFrame({
         "id": ["sample"],
         "label": ["hello world"],
     }).to_csv(csv_path, sep=";", index=False)
+
+
+def _create_openface_data(h5_path, csv_path):
+    """Create HDF5 file including OpenFace features."""
+    with h5py.File(h5_path, "w") as h5:
+        grp = h5.create_group("sample.mp4")
+        T = 2
+        grp.create_dataset("pose", data=np.zeros((T, 33 * 3), np.float32))
+        grp.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
+        grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
+        grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
+        grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
+        grp.create_dataset("head_pose", data=np.zeros((T, 3), np.float32))
+        grp.create_dataset("torso_pose", data=np.zeros((T, 3), np.float32))
+        grp.create_dataset("aus", data=np.zeros((T, 2), np.float32))
+    pd.DataFrame({"id": ["sample"], "label": ["hello world"]}).to_csv(csv_path, sep=";", index=False)
 
 
 def test_dataset_loading(tmp_path):
@@ -109,4 +125,14 @@ def test_dataset_segments(tmp_path):
         assert ds.samples[0][0].endswith("segment_000")
         x, *_ = ds[0]
         assert x.shape == (3, 2, 544)
+
+
+def test_dataset_openface(tmp_path):
+    h5_file = tmp_path / "data.h5"
+    csv_file = tmp_path / "labels.csv"
+    _create_openface_data(h5_file, csv_file)
+    with SignDataset(str(h5_file), str(csv_file), include_openface=True) as ds:
+        x, *_ = ds[0]
+        assert x.shape[2] == 548
+        assert ds.num_nodes == 548
 

--- a/utils/build_adjacency.py
+++ b/utils/build_adjacency.py
@@ -1,14 +1,59 @@
 from __future__ import annotations
-import yaml
 import numpy as np
 from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - fallback if PyYAML is missing
+    yaml = None
+
+
+def _load_config(path: Path) -> dict:
+    """Load YAML configuration or use a minimal fallback parser."""
+    if yaml is not None:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    data: dict[str, dict] = {}
+    current: str | None = None
+    anchors: dict[str, list] = {}
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            if not line.startswith(" "):
+                key = line.split(":", 1)[0]
+                current = key
+                data[current] = {}
+                continue
+            if current is None:
+                continue
+            item = line.strip()
+            if item.startswith("count:"):
+                data[current]["count"] = int(item.split(":", 1)[1].strip())
+            elif item.startswith("connections:"):
+                if "&" in item:
+                    name = item.split("&", 1)[1].strip()
+                    anchors[name] = []
+                    data[current]["connections"] = anchors[name]
+                elif "*" in item:
+                    alias = item.split("*", 1)[1].strip()
+                    data[current]["connections"] = list(anchors.get(alias, []))
+                else:
+                    data[current]["connections"] = []
+            elif item.startswith("-"):
+                parts = item.strip("-[] ").split(",")
+                if len(parts) >= 2:
+                    a, b = int(parts[0]), int(parts[1])
+                    data[current].setdefault("connections", []).append([a, b])
+    return data
 
 
 def build_adjacency(path: str | Path) -> np.ndarray:
     """Build an adjacency matrix from a skeleton YAML config."""
     path = Path(path)
-    with path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    data = _load_config(path)
 
     offsets = {}
     offset = 0


### PR DESCRIPTION
## Summary
- include `head_pose`, `torso_pose` and `aus` data in `SignDataset`
- extend adjacency parser with builtin YAML fallback
- expand skeleton configuration with the new nodes
- expose `--include_openface` flag in train script
- test dataset loading when OpenFace information is available

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68864b9639f08331a7c27178a228ccef