### PR TITLE
Add YAML configuration defaults

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -145,6 +145,14 @@ python distill.py --h5_file datos.h5 --csv_file labels.csv \
 El script guarda el checkpoint reducido en `checkpoints/` y reporta WER y
 precisión de NMM comparando alumno y profesor.
 
+### 5.3 Configuración por defecto
+
+Los scripts de entrenamiento, exportación y distilación pueden leer valores
+por omisión desde `configs/config.yaml`. Si una opción de la línea de comandos
+no se proporciona, se utilizará el valor definido en este archivo. Allí se
+especifican las rutas de los datasets, la carpeta de `checkpoints`, la
+arquitectura del modelo y los hiperparámetros más comunes.
+
 ---
 
 ## 6. Despliegue y Monitoreo

--- a/active_learning.py
+++ b/active_learning.py
@@ -2,6 +2,7 @@
 """Selecciona ejemplos de baja confianza para reentrenamiento."""
 import os
 import argparse
+from pathlib import Path
 import h5py
 import torch
 from torch.utils.data import DataLoader
@@ -75,13 +76,19 @@ def copy_videos(paths: List[str], out_dir: str) -> None:
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Proceso simple de active learning")
-    p.add_argument("--checkpoint", required=True, help="Modelo entrenado")
-    p.add_argument("--h5_file", required=True)
-    p.add_argument("--csv_file", required=True)
-    p.add_argument("--out_dir", required=True)
-    p.add_argument("--top_k", type=int, default=10, help="Cantidad de ejemplos a seleccionar")
+    p.add_argument("--checkpoint")
+    p.add_argument("--h5_file")
+    p.add_argument("--csv_file")
+    p.add_argument("--out_dir")
+    p.add_argument("--top_k", type=int)
     p.add_argument("--log_file", help="CSV con registros de producción")
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / "configs" / "config.yaml"
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
 
     with SignDataset(args.h5_file, args.csv_file) as ds:
         dl = DataLoader(ds, batch_size=1, shuffle=False, collate_fn=collate)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,21 @@
+# Default configuration for scripts
+
+dataset:
+  h5_file: data/data.h5
+  csv_file: data/labels.csv
+  domain_csv: null
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: checkpoints/teacher.pt
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 10
+  batch_size: 4
+  initial_length: 0
+  length_schedule: ""
+  mask_prob: 0.15
+  seq_len: 16

--- a/distill.py
+++ b/distill.py
@@ -252,17 +252,24 @@ def distill(args: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser(description="Distil a model using KL divergence")
-    p.add_argument("--h5_file", required=True)
-    p.add_argument("--csv_file", required=True)
-    p.add_argument("--teacher_ckpt", required=True)
+    p.add_argument("--h5_file")
+    p.add_argument("--csv_file")
+    p.add_argument("--teacher_ckpt")
     p.add_argument(
         "--model",
         default="stgcn",
         choices=["stgcn", "sttn", "corrnet+", "mcst"],
         help="Arquitectura del modelo",
     )
-    p.add_argument("--batch_size", type=int, default=4)
-    p.add_argument("--epochs", type=int, default=5)
+    p.add_argument("--batch_size", type=int)
+    p.add_argument("--epochs", type=int)
     p.add_argument("--domain_labels", help="CSV con etiquetas de dominio opcional")
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / "configs" / "config.yaml"
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
+
     distill(args)

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 import torch
 from torch import nn
 
@@ -24,14 +25,19 @@ def main() -> None:
     p = argparse.ArgumentParser(
         description="Exportar checkpoint a ONNX y cuantizar dinamicamente"
     )
-    p.add_argument("--checkpoint", required=True, help="Ruta al checkpoint")
-    p.add_argument("--arch", default="stgcn",
+    p.add_argument("--checkpoint")
+    p.add_argument("--arch",
                    choices=["stgcn", "sttn", "corrnet+", "mcst"],
                    help="Arquitectura del modelo")
-    p.add_argument("--output", required=True, help="Archivo onnx de salida")
-    p.add_argument("--seq_len", type=int, default=16,
-                   help="Longitud de secuencia dummy")
+    p.add_argument("--output")
+    p.add_argument("--seq_len", type=int)
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / "configs" / "config.yaml"
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
 
     model = load_model(args.checkpoint, args.arch)
     dummy = torch.zeros(1, 3, args.seq_len, 544)

--- a/infer.py
+++ b/infer.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 import os
 from typing import Dict, List, Tuple
 
@@ -77,14 +78,20 @@ def load_vocab(path: str) -> Dict[int, str]:
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Inferencia con beam-search")
-    p.add_argument("--checkpoint", required=True, help="Modelo de reconocimiento")
-    p.add_argument("--lm", required=True, help="Checkpoint LM")
-    p.add_argument("--vocab", required=True, help="Archivo vocabulario (uno por l\u00ednea)")
-    p.add_argument("--video", required=True, help="Video de entrada")
-    p.add_argument("--h5", required=True, help="HDF5 con features")
-    p.add_argument("--beam", type=int, default=5, help="Tama\u00f1o de beam")
+    p.add_argument("--checkpoint", help="Modelo de reconocimiento")
+    p.add_argument("--lm", help="Checkpoint LM")
+    p.add_argument("--vocab", help="Archivo vocabulario (uno por línea)")
+    p.add_argument("--video", help="Video de entrada")
+    p.add_argument("--h5", help="HDF5 con features")
+    p.add_argument("--beam", type=int, default=5, help="Tamaño de beam")
     p.add_argument("--lm_weight", type=float, default=0.5, help="Peso del LM")
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / "configs" / "config.yaml"
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
 
     vocab = load_vocab(args.vocab)
     feat = load_features(args.video, args.h5)

--- a/pretrain_shubert.py
+++ b/pretrain_shubert.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+from pathlib import Path
 import os
 import h5py
 import numpy as np
@@ -75,9 +76,16 @@ def train(args):
 
 if __name__ == '__main__':
     p = argparse.ArgumentParser(description='Pretrain SHuBERT with self-supervised masking')
-    p.add_argument('--h5_file', required=True)
-    p.add_argument('--epochs', type=int, default=10)
-    p.add_argument('--batch_size', type=int, default=8)
-    p.add_argument('--mask_prob', type=float, default=0.15)
+    p.add_argument('--h5_file')
+    p.add_argument('--epochs', type=int)
+    p.add_argument('--batch_size', type=int)
+    p.add_argument('--mask_prob', type=float)
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / 'configs' / 'config.yaml'
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
+
     train(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ jiwer
 numpy==1.26.4
 opencv-python==4.8.1.78
 tqdm
+pyyaml
 
 ruptures
 

--- a/server/export_model.py
+++ b/server/export_model.py
@@ -1,15 +1,22 @@
 import argparse
+from pathlib import Path
 import torch
 from torch import nn
 
 
 def main():
     p = argparse.ArgumentParser(description="Exportar modelo a TorchScript u ONNX")
-    p.add_argument("--checkpoint", required=True, help="Ruta al checkpoint de PyTorch")
-    p.add_argument("--output", required=True, help="Archivo de salida")
+    p.add_argument("--checkpoint")
+    p.add_argument("--output")
     p.add_argument("--onnx", action="store_true", help="Exportar en formato ONNX")
-    p.add_argument("--seq_len", type=int, default=16, help="Longitud de secuencia simulada")
+    p.add_argument("--seq_len", type=int)
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parents[1] / "configs" / "config.yaml"
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
 
     model = torch.load(args.checkpoint, map_location="cpu")
     if isinstance(model, nn.Module):

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import argparse
+from pathlib import Path
 import h5py
 import pandas as pd
 import numpy as np
@@ -575,16 +576,23 @@ def train(args):
 
 if __name__ == '__main__':
     p = argparse.ArgumentParser(description='Train sign language models with CTC loss')
-    p.add_argument('--h5_file', required=True, help='HDF5 file with landmarks and optical flow')
-    p.add_argument('--csv_file', required=True, help='CSV file with transcripts')
-    p.add_argument('--epochs', type=int, default=10)
-    p.add_argument('--batch_size', type=int, default=4)
-    p.add_argument('--model', type=str, default='stgcn', choices=['stgcn', 'sttn', 'corrnet+', 'mcst'], help='Model architecture')
+    p.add_argument('--h5_file', help='HDF5 file with landmarks and optical flow')
+    p.add_argument('--csv_file', help='CSV file with transcripts')
+    p.add_argument('--epochs', type=int)
+    p.add_argument('--batch_size', type=int)
+    p.add_argument('--model', type=str, choices=['stgcn', 'sttn', 'corrnet+', 'mcst'], help='Model architecture')
     p.add_argument('--domain_labels', help='CSV con etiquetas de dominio opcional')
     p.add_argument('--contrastive', action='store_true', help='Use contrastive loss')
     p.add_argument('--segments', action='store_true', help='Load segment_* subgroups as separate samples')
     p.add_argument('--include_openface', action='store_true', help='Load head/torso pose and AUs if present')
-    p.add_argument('--initial_length', type=int, default=0, help='Initial maximum sequence length')
-    p.add_argument('--length_schedule', default='', help='Comma separated maximum lengths for subsequent epochs')
+    p.add_argument('--initial_length', type=int)
+    p.add_argument('--length_schedule', help='Comma separated maximum lengths for subsequent epochs')
     args = p.parse_args()
+
+    cfg_path = Path(__file__).resolve().parent / 'configs' / 'config.yaml'
+    from utils.config import load_config, apply_defaults
+
+    cfg = load_config(cfg_path)
+    apply_defaults(args, cfg)
+
     train(args)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    yaml = None
+
+
+def load_config(path: str | Path) -> dict:
+    """Load YAML configuration file with a minimal fallback parser."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    if yaml is not None:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    data: dict[str, dict] = {}
+    current: dict | None = None
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            if line.startswith(" ") and current is not None:
+                key, _, val = line.strip().partition(":")
+                val = val.strip()
+                try:
+                    current[key] = ast.literal_eval(val)
+                except Exception:
+                    current[key] = val
+                continue
+            key, _, val = line.partition(":")
+            val = val.strip()
+            if val:
+                try:
+                    data[key] = ast.literal_eval(val)
+                except Exception:
+                    data[key] = val
+                current = None
+            else:
+                current = {}
+                data[key] = current
+    return data
+
+
+def apply_defaults(args: SimpleNamespace, cfg: dict) -> None:
+    """Fill missing attributes in ``args`` with values from ``cfg``."""
+    for section in ("dataset", "checkpoints", "hyperparameters", "model"):
+        defaults = cfg.get(section, {})
+        for key, val in defaults.items():
+            if not hasattr(args, key) or getattr(args, key) in (None, ""):
+                setattr(args, key, val)


### PR DESCRIPTION
## Summary
- add `configs/config.yaml` with defaults for dataset paths, checkpoints, hyperparameters and model
- provide a helper (`utils/config.py`) to load YAML without PyYAML
- update CLI scripts to load missing arguments from the configuration
- document the configuration file in the README
- add pyyaml to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch, numpy)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch==2.2.1+cu118)*

------
https://chatgpt.com/codex/tasks/task_e_688d55e31790833184b42f1806b4ba66