### PR TITLE
Add morphology vocab support and meta enrichment workflow

### DIFF
--- a/data/download.py
+++ b/data/download.py
@@ -114,6 +114,10 @@ def download_dataset(name: str, dest: str, url: Optional[str] = None, checksum: 
         raise RuntimeError("Checksum mismatch for downloaded file")
     _extract_archive(archive_path, dest)
     _normalize(dest)
+    meta_path = os.path.join(dest, "meta.csv")
+    if os.path.exists(meta_path):
+        from data import meta_generator
+        meta_generator.main(meta_path, meta_path)
 
 
 def main() -> None:

--- a/tests/test_meta_generator.py
+++ b/tests/test_meta_generator.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+import h5py
+from data import meta_generator
+from train import SignDataset
+
+
+def test_meta_generator_vocab(tmp_path, monkeypatch):
+    h5_file = tmp_path / "data.h5"
+    with h5py.File(h5_file, "w") as h5:
+        for vid in ["a.mp4", "b.mp4"]:
+            grp = h5.create_group(vid)
+            T = 1
+            grp.create_dataset("pose", data=np.zeros((T, 33 * 3), np.float32))
+            grp.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
+            grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
+            grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
+            grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
+    raw_csv = tmp_path / "raw.csv"
+    pd.DataFrame({
+        "id": ["a", "b"],
+        "label": ["first", "second"],
+    }).to_csv(raw_csv, sep=";", index=False)
+    out_csv = tmp_path / "meta.csv"
+
+    def fake_extract(text, nlp):
+        if text == "first":
+            return ("1", "sg", "pres", "simple", "ind")
+        return ("3", "pl", "past", "perf", "subj")
+
+    monkeypatch.setattr(meta_generator, "_extract_morph", fake_extract)
+    meta_generator.main(str(raw_csv), str(out_csv))
+
+    with SignDataset(str(h5_file), str(out_csv)) as ds:
+        assert len(ds.person_vocab) > 1
+        assert len(ds.number_vocab) > 1
+        assert len(ds.tense_vocab) > 1
+        assert len(ds.aspect_vocab) > 1
+        assert len(ds.mode_vocab) > 1


### PR DESCRIPTION
## Summary
- Run `meta_generator.py` after dataset normalization to enrich metadata
- Extend `SignDataset` and training CLI to handle morphology columns and omit heads when absent
- Add tests ensuring `meta_generator.py` produces non-default morphology vocabularies

## Testing
- `pytest tests/test_meta_generator.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -q numpy==1.26.4 pandas h5py torch==2.2.1 torchvision==0.17.1 torchaudio==2.2.1` *(fails: Could not find a version that satisfies the requirement numpy==1.26.4)*

------
https://chatgpt.com/codex/tasks/task_e_688f8f5e9bbc8331a9b83c57873af80a