### PR TITLE
Improve dataset download robustness

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4,6 +4,8 @@ import sys
 import zipfile
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from importlib import import_module
 
@@ -17,7 +19,9 @@ def test_verify_checksum(tmp_path):
     content = b"hello"
     file.write_bytes(content)
     digest = hashlib.sha256(content).hexdigest()
-    assert _verify_checksum(str(file), digest)
+    _verify_checksum(str(file), digest)
+    with pytest.raises(RuntimeError):
+        _verify_checksum(str(file), "bad")
 
 
 def test_extract_archive(tmp_path):


### PR DESCRIPTION
## Summary
- replace placeholder dataset URLs and checksums with real resources
- add retry logic, timeout, and clearer errors to dataset downloader
- make checksum verification raise descriptive exceptions and update tests

## Testing
- `pytest tests/test_download.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', torch)*

------
https://chatgpt.com/codex/tasks/task_e_6890005b77a48331803b419275a63c95