### PR TITLE
Order standard library imports for feature extraction

### DIFF
--- a/server/feature_extraction.py
+++ b/server/feature_extraction.py
@@ -1,7 +1,7 @@
 import os
-import tempfile
-import subprocess
 import shutil
+import subprocess
+import tempfile
 from typing import Optional
 
 import cv2


### PR DESCRIPTION
## Summary
- Ensure `server/feature_extraction.py` explicitly imports `os`, `shutil`, `subprocess`, and `tempfile`
- Verified helper functions use these modules without undefined names

## Testing
- `pyflakes server/feature_extraction.py`
- `python -m py_compile server/feature_extraction.py`
- `PYTHONPATH=. pytest tests/test_landmarks.py::test_extract_features -q` *(fails: ImportError: cannot import name 'File' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68901074a8e88331b98761d00ecdb1d6