### PR TITLE
Ensure os and torch imports are grouped at top

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -1,7 +1,9 @@
 import os
+
 import torch
 import mediapipe as mp
 from ultralytics import YOLO
+
 from metrics import MetricsLogger
 
 try:  # optional dependency for YOLOX and ONNX backend


### PR DESCRIPTION
## Summary
- group os and torch imports at the top of `server/models.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689010754b288331b8e2aa589e24ce45