### PR TITLE
Ensure inference script imports are explicit

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -1,7 +1,7 @@
+import os
 import argparse
 from pathlib import Path
-import os
-from typing import Dict, List, Tuple
+from typing import List, Dict
 
 import h5py
 import numpy as np


### PR DESCRIPTION
## Summary
- Reorder and consolidate top-level imports in `infer.py`

## Testing
- `python -m py_compile infer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6890107e898c8331876824969a81aee7