### PR TITLE
Lazy load models at startup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -7,11 +7,25 @@ from fastapi import FastAPI, File, UploadFile, WebSocket, WebSocketDisconnect
 import uvicorn
 
 from .decoder import decode
-from .feature_extraction import extract_features_from_bytes, pad_batch
-from .models import GRPC_AVAILABLE, device, logger, model, onnx_sess, start_grpc_server
+from .feature_extraction import _extract_features, extract_features_from_bytes, pad_batch
+from .models import (
+    GRPC_AVAILABLE,
+    device,
+    logger,
+    load_models,
+    model,
+    onnx_sess,
+    start_grpc_server,
+)
 
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def _load_models() -> None:
+    """Load models at application startup."""
+    load_models()
 
 
 @app.on_event("shutdown")
@@ -99,6 +113,7 @@ async def websocket_endpoint(ws: WebSocket):
 
 
 if __name__ == "__main__":
+    load_models()
     if GRPC_AVAILABLE:
         start_grpc_server()
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/server/feature_extraction.py
+++ b/server/feature_extraction.py
@@ -10,7 +10,7 @@ import pandas as pd
 import torch
 
 from optical_flow.raft_runner import compute_optical_flow
-from .models import OPENFACE_BIN, holistic_model, yolo_model, yolox_sess
+from .models import OPENFACE_BIN, holistic_model, load_models, yolo_model, yolox_sess
 
 
 def _run_openface(path: str) -> Optional[np.ndarray]:
@@ -59,6 +59,9 @@ def extract_features_from_bytes(data: bytes) -> torch.Tensor:
 
 def _extract_features(path: str) -> torch.Tensor:
     """Compute landmarks and optical flow for a video path."""
+    if holistic_model is None or (yolo_model is None and yolox_sess is None):
+        load_models()
+
     cap = cv2.VideoCapture(path)
     of_feats = _run_openface(path)
     n_aus = of_feats.shape[1] - 3 if of_feats is not None else 0


### PR DESCRIPTION
## Summary
- defer heavy model and session initialization until `load_models()` is called
- call `load_models()` on FastAPI startup and before launching the gRPC server
- ensure feature extraction triggers model loading if invoked directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_e_689029847c748331b32058e1a6d3737b