### PR TITLE
Log websocket client disconnects

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -95,7 +95,8 @@ async def websocket_endpoint(ws: WebSocket):
             logger.log(latency=latency, fps=fps)
             await ws.send_json({"transcript": transcript})
     except WebSocketDisconnect:
-        pass
+        logger.log(class_acc={"message": "Client disconnected."})
+        await ws.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log client disconnections in websocket endpoint
- ensure websocket resources are closed on disconnect

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6890297085388331b379b4d23cd67dd3