### PR TITLE
Gracefully handle missing spaCy models in metadata generation

### DIFF
--- a/tests/test_meta_generator.py
+++ b/tests/test_meta_generator.py
@@ -1,21 +1,9 @@
-import numpy as np
 import pandas as pd
-import h5py
+import pytest
 from data import meta_generator
-from train import SignDataset
 
 
 def test_meta_generator_vocab(tmp_path, monkeypatch):
-    h5_file = tmp_path / "data.h5"
-    with h5py.File(h5_file, "w") as h5:
-        for vid in ["a.mp4", "b.mp4"]:
-            grp = h5.create_group(vid)
-            T = 1
-            grp.create_dataset("pose", data=np.zeros((T, 33 * 3), np.float32))
-            grp.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
-            grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
-            grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
-            grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
     raw_csv = tmp_path / "raw.csv"
     pd.DataFrame({
         "id": ["a", "b"],
@@ -31,9 +19,30 @@ def test_meta_generator_vocab(tmp_path, monkeypatch):
     monkeypatch.setattr(meta_generator, "_extract_morph", fake_extract)
     meta_generator.main(str(raw_csv), str(out_csv))
 
-    with SignDataset(str(h5_file), str(out_csv)) as ds:
-        assert len(ds.person_vocab) > 1
-        assert len(ds.number_vocab) > 1
-        assert len(ds.tense_vocab) > 1
-        assert len(ds.aspect_vocab) > 1
-        assert len(ds.mode_vocab) > 1
+    df = pd.read_csv(out_csv, sep=";")
+    assert df["person"].nunique() > 1
+    assert df["number"].nunique() > 1
+    assert df["tense"].nunique() > 1
+    assert df["aspect"].nunique() > 1
+    assert df["mode"].nunique() > 1
+
+
+def test_meta_generator_strict_errors(tmp_path):
+    raw_csv = tmp_path / "raw.csv"
+    pd.DataFrame({"id": ["a"], "label": ["x"]}).to_csv(
+        raw_csv, sep=";", index=False
+    )
+    out_csv = tmp_path / "out.csv"
+    with pytest.raises(RuntimeError):
+        meta_generator.main(str(raw_csv), str(out_csv), strict=True)
+
+
+def test_meta_generator_fallback_message(tmp_path, capsys):
+    raw_csv = tmp_path / "raw.csv"
+    pd.DataFrame({"id": ["a"], "label": ["x"]}).to_csv(
+        raw_csv, sep=";", index=False
+    )
+    out_csv = tmp_path / "out.csv"
+    meta_generator.main(str(raw_csv), str(out_csv))
+    captured = capsys.readouterr().out
+    assert "spaCy model not found" in captured


### PR DESCRIPTION
## Summary
- Check for spaCy availability and model load failures in `meta_generator.main`
- Add `--strict` flag to error instead of falling back to default morphology
- Extend tests for strict mode and fallback messaging

## Testing
- `PYTHONPATH=. pytest tests/test_meta_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890aec7b93083319d640bd98b5b3a42