### PR TITLE
Ensure os imported in pipeline tests

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,5 @@
-import os
 import sys
+import os
 from types import SimpleNamespace
 
 import numpy as np


### PR DESCRIPTION
## Summary
- ensure `tests/test_pipeline.py` imports `os` alongside other core modules

## Testing
- `pytest tests/test_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6890aec92ba0833192eccbed5bb912ad