### PR TITLE
Reorder imports in server app

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,7 +1,7 @@
+import logging
 import os
 import time
 import uuid
-import logging
 
 import torch
 from fastapi import FastAPI, File, UploadFile, WebSocket, WebSocketDisconnect


### PR DESCRIPTION
## Summary
- Ensure standard library imports (logging, os, time, uuid) are declared at the top of `server/app.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'train')*

------
https://chatgpt.com/codex/tasks/task_e_6890bb771aec8331acf898d218b18d8b