### PR TITLE
Handle spaCy availability in meta generator

### DIFF
--- a/data/meta_generator.py
+++ b/data/meta_generator.py
@@ -3,11 +3,6 @@ from typing import Tuple
 
 import pandas as pd
 
-try:
-    import spacy
-except Exception:  # pragma: no cover - optional dependency
-    spacy = None
-
 
 _DEF_MODEL = "es_core_news_sm"
 
@@ -31,7 +26,9 @@ def _extract_morph(text: str, nlp) -> Tuple[str, str, str, str, str]:
 def main(inp: str, out: str, model: str = _DEF_MODEL, strict: bool = False) -> None:
     df = pd.read_csv(inp, sep=";")
     nlp = None
-    if spacy is None:
+    try:
+        import spacy  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
         if strict:
             raise RuntimeError("spaCy is not installed")
         print("spaCy model not found; writing default morphology")


### PR DESCRIPTION
## Summary
- Skip morphology enrichment when spaCy or its model can't be loaded, with a clear message
- Allow an optional `--strict` flag to error on missing spaCy model

## Testing
- `python -m pytest tests/test_meta_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c1286afc83318b49892e5fd54e14