### PR TITLE
Refactor ONNX exporter imports

### DIFF
--- a/export_onnx.py
+++ b/export_onnx.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 
 from train import build_model
+from utils.config import load_config, apply_defaults
 
 
 def load_model(checkpoint: Path, arch: str) -> nn.Module:
@@ -34,7 +35,6 @@ def main() -> None:
     args = p.parse_args()
 
     cfg_path = Path(__file__).resolve().parent / "configs" / "config.yaml"
-    from utils.config import load_config, apply_defaults
 
     cfg = load_config(cfg_path)
     apply_defaults(args, cfg)


### PR DESCRIPTION
## Summary
- centralize ONNX exporter imports and config helpers for argument and path handling

## Testing
- `PYTHONPATH=. pytest tests/test_models.py::test_stgcn_forward -q` *(fails: RuntimeError: einsum(): subscript v has size 563 for operand 1 which does not broadcast with previously seen size 544)*

------
https://chatgpt.com/codex/tasks/task_e_6890c12bb3588331a28a0f0e667652f6