### PR TITLE
Add configuration examples and validation

### DIFF
--- a/configs/config_dann.yaml
+++ b/configs/config_dann.yaml
@@ -1,0 +1,26 @@
+# Domain-Adversarial Neural Network training example
+
+dataset:
+  h5_file: data/data.h5
+  features_h5: data/features.h5
+  csv_file: data/labels.csv
+  domain_csv: data/domains.csv
+  vocab: vocab.txt
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: null
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 10
+  batch_size: 4
+  seq_len: 16
+  max_seq_len: 128
+  learning_rate: 0.001
+  adversarial: true
+  adv_mix_rate: 0.5
+  adv_weight: 0.1
+  adv_steps: 1

--- a/configs/config_distill.yaml
+++ b/configs/config_distill.yaml
@@ -1,0 +1,22 @@
+# Knowledge distillation training example
+
+dataset:
+  h5_file: data/data.h5
+  features_h5: data/features.h5
+  csv_file: data/labels.csv
+  vocab: vocab.txt
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: checkpoints/teacher.pt
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 10
+  batch_size: 4
+  seq_len: 16
+  max_seq_len: 128
+  learning_rate: 0.001
+  aux_loss_weight: 0.1

--- a/configs/config_lm.yaml
+++ b/configs/config_lm.yaml
@@ -1,0 +1,26 @@
+# Decoding with an external language model
+
+dataset:
+  h5_file: data/data.h5
+  features_h5: data/features.h5
+  csv_file: data/labels.csv
+  vocab: vocab.txt
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: checkpoints/model.pt
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 10
+  batch_size: 4
+  seq_len: 16
+  max_seq_len: 128
+  learning_rate: 0.001
+
+decoder:
+  lm_ckpt: checkpoints/lm.ckpt
+  lm_weight: 0.5
+  beam_size: 5

--- a/configs/config_long_seq.yaml
+++ b/configs/config_long_seq.yaml
@@ -1,0 +1,23 @@
+# Training with longer input sequences
+
+dataset:
+  h5_file: data/data.h5
+  features_h5: data/features.h5
+  csv_file: data/labels.csv
+  vocab: vocab.txt
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: null
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 10
+  batch_size: 2
+  initial_length: 16
+  length_schedule: linear
+  seq_len: 64
+  max_seq_len: 256
+  learning_rate: 0.001

--- a/configs/config_scratch.yaml
+++ b/configs/config_scratch.yaml
@@ -1,0 +1,21 @@
+# Training from scratch with minimal defaults
+
+dataset:
+  h5_file: data/data.h5
+  features_h5: data/features.h5
+  csv_file: data/labels.csv
+  vocab: vocab.txt
+
+checkpoints:
+  dir: checkpoints
+  teacher_ckpt: null
+
+model:
+  arch: stgcn
+
+hyperparameters:
+  epochs: 20
+  batch_size: 8
+  seq_len: 32
+  max_seq_len: 128
+  learning_rate: 0.001

--- a/utils/config.py
+++ b/utils/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 from types import SimpleNamespace
+import warnings
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore
@@ -47,6 +48,62 @@ def load_config(path: str | Path) -> dict:
     return data
 
 
+def validate_config(args: SimpleNamespace) -> None:
+    """Emit warnings for out-of-range or inconsistent parameters."""
+
+    def warn(msg: str) -> None:
+        warnings.warn(msg, stacklevel=2)
+
+    # dataset paths
+    for attr in ("h5_file", "features_h5", "csv_file", "vocab", "domain_csv"):
+        path = getattr(args, attr, None)
+        if path and not Path(path).exists():
+            warn(f"{attr} path not found: {path}")
+
+    tckpt = getattr(args, "teacher_ckpt", None)
+    if tckpt and not Path(tckpt).exists():
+        warn(f"teacher_ckpt path not found: {tckpt}")
+
+    # hyperparameters
+    if getattr(args, "epochs", 1) < 1:
+        warn("epochs should be >= 1")
+    if not 1 <= getattr(args, "batch_size", 1) <= 1024:
+        warn("batch_size should be between 1 and 1024")
+    if getattr(args, "initial_length", 0) < 0:
+        warn("initial_length should be >= 0")
+    if not 0 <= getattr(args, "mask_prob", 0) <= 1:
+        warn("mask_prob should be between 0 and 1")
+    if getattr(args, "seq_len", 1) < 1:
+        warn("seq_len should be >= 1")
+    lr = getattr(args, "learning_rate", 0.0)
+    if lr and not (1e-6 <= lr <= 1e-1):
+        warn("learning_rate should be between 1e-6 and 1e-1")
+    if not 1 <= getattr(args, "joint_count", 1) <= 1000:
+        warn("joint_count should be between 1 and 1000")
+    if getattr(args, "max_seq_len", 1) < getattr(args, "seq_len", 1):
+        warn("max_seq_len should be >= seq_len")
+    if getattr(args, "pose_loss_weight", 0) < 0:
+        warn("pose_loss_weight should be >= 0")
+    if getattr(args, "aux_loss_weight", 0) < 0:
+        warn("aux_loss_weight should be >= 0")
+
+    # adversarial training parameters
+    if getattr(args, "adversarial", False):
+        if not 0 <= getattr(args, "adv_mix_rate", 1.0) <= 1:
+            warn("adv_mix_rate should be between 0 and 1 when adversarial is enabled")
+        if getattr(args, "adv_weight", 0) < 0:
+            warn("adv_weight should be >= 0 when adversarial is enabled")
+        if getattr(args, "adv_steps", 1) < 1:
+            warn("adv_steps should be >= 1 when adversarial is enabled")
+    else:
+        if (
+            getattr(args, "adv_weight", 0) != 0
+            or getattr(args, "adv_steps", 1) != 1
+            or getattr(args, "adv_mix_rate", 1.0) != 1.0
+        ):
+            warn("adversarial parameters provided but adversarial is disabled")
+
+
 def apply_defaults(args: SimpleNamespace, cfg: dict) -> None:
     """Fill missing attributes in ``args`` with values from ``cfg``."""
     for section in ("dataset", "checkpoints", "hyperparameters", "model"):
@@ -54,3 +111,4 @@ def apply_defaults(args: SimpleNamespace, cfg: dict) -> None:
         for key, val in defaults.items():
             if not hasattr(args, key) or getattr(args, key) in (None, ""):
                 setattr(args, key, val)
+    validate_config(args)


### PR DESCRIPTION
## Summary
- add several example `config.yaml` variants for scratch training, distillation, DANN, long sequences, and LM decoding
- validate configuration values and warn when out of range or inconsistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy fastapi torch pandas websockets` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_689104dcc4608331b0a1be1119b5dc5a