### PR TITLE
Handle unknown archive types during download

### DIFF
--- a/data/download.py
+++ b/data/download.py
@@ -121,6 +121,8 @@ def _extract_archive(path: str, dest: str) -> None:
     elif tarfile.is_tarfile(path):
         with tarfile.open(path) as tf:
             tf.extractall(dest)
+    else:
+        raise RuntimeError(f"Unknown archive type for {path}")
 
 
 def _normalize(dest: str) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -31,3 +31,10 @@ def test_extract_archive(tmp_path):
     out_dir = tmp_path / "out"
     _extract_archive(str(zpath), str(out_dir))
     assert (out_dir / "a" / "b.txt").read_text() == "ok"
+
+
+def test_extract_archive_unknown(tmp_path):
+    unknown = tmp_path / "archive.bin"
+    unknown.write_bytes(b"not-an-archive")
+    with pytest.raises(RuntimeError):
+        _extract_archive(str(unknown), str(tmp_path / "out"))


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when download helper encounters an unsupported archive format
- test archive extraction failure on unsupported file types

## Testing
- `pytest tests/test_download.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68911b62a3f4833191b027bd1d8f2963