### PR TITLE
Handle unknown archive formats in downloader

### DIFF
--- a/data/download.py
+++ b/data/download.py
@@ -121,6 +121,8 @@ def _extract_archive(path: str, dest: str) -> None:
     elif tarfile.is_tarfile(path):
         with tarfile.open(path) as tf:
             tf.extractall(dest)
+    else:
+        raise RuntimeError(f"Unsupported archive format: {path}")
 
 
 def _normalize(dest: str) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -36,6 +36,14 @@ def test_extract_archive(tmp_path):
     assert (out_dir / "a" / "b.txt").read_text() == "ok"
 
 
+def test_extract_unknown_archive(tmp_path):
+    path = tmp_path / "file.bin"
+    path.write_text("data")
+    out_dir = tmp_path / "out"
+    with pytest.raises(RuntimeError):
+        _extract_archive(str(path), str(out_dir))
+
+
 def test_normalize(tmp_path):
     dest = tmp_path / "data"
     sub = dest / "sub"


### PR DESCRIPTION
## Summary
- raise RuntimeError for unsupported archive files in `_extract_archive`
- add unit test covering unknown archive extraction

## Testing
- `pytest tests/test_download.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68913b3600b48331a96bdef711b914d3