### PR TITLE
Add subset evaluation script and architecture comparison test

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,30 @@
+# Benchmarks
+
+Este proyecto incluye utilidades para evaluar modelos de reconocimiento de se\xC3\xB1as.
+
+## WER/CER en un subconjunto de validaci\xC3\xB3n
+
+El script `scripts/evaluate_subset.py` usa `evaluate.py` para calcular **WER** y **CER**
+sobre un subconjunto aleatorio de la partici\xC3\xB3n de validaci\xC3\xB3n. Se requieren los
+archivos `HDF5` con landmarks y el `CSV` de etiquetas.
+
+```bash
+python scripts/evaluate_subset.py --h5_file data/val.h5 --csv_file data/val.csv \
+    --checkpoint checkpoints/model.pt --model stgcn --subset 100
+```
+
+Los corpora pueden descargarse con `data/download.py`, que deja los datos en el
+directorio indicado. Los ejemplos peque\xC3\xB1os para pruebas se encuentran en `tests/data/`.
+
+## Comparaci\xC3\xB3n de arquitecturas
+
+Para comparar arquitecturas como `stgcn` y `sttn` en el mismo corpus, ejecute el
+test dedicado:
+
+```bash
+pytest tests/test_architecture_benchmark.py -s
+```
+
+La prueba genera un JSON con los valores de WER y CER por modelo y utiliza los
+datos de ejemplo creados al vuelo. Para conjuntos reales, proporcione rutas a
+los archivos correspondientes como en el script anterior.

--- a/scripts/evaluate_subset.py
+++ b/scripts/evaluate_subset.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Compute WER and CER on a random validation subset using evaluate.py."""
+import argparse
+import json
+import random
+from functools import partial
+
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader, Subset
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from train import SignDataset, collate, build_model  # noqa: E402
+from evaluate import compute_metrics  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate WER/CER on a subset")
+    parser.add_argument("--h5_file", required=True, help="HDF5 file with landmarks")
+    parser.add_argument("--csv_file", required=True, help="CSV file with labels")
+    parser.add_argument("--checkpoint", required=True, help="Model checkpoint path")
+    parser.add_argument(
+        "--model",
+        choices=["stgcn", "sttn", "corrnet+", "mcst"],
+        default="stgcn",
+    )
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument(
+        "--subset",
+        type=int,
+        default=100,
+        help="Number of validation samples to evaluate",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--segments", action="store_true", help="Use segmented samples")
+    parser.add_argument(
+        "--include_openface", action="store_true", help="Include extra OpenFace features"
+    )
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    with SignDataset(
+        args.h5_file,
+        args.csv_file,
+        segments=args.segments,
+        include_openface=args.include_openface,
+    ) as ds:
+        idx = list(range(len(ds)))
+        random.shuffle(idx)
+        idx = idx[: args.subset]
+        subset = Subset(ds, idx)
+        dl = DataLoader(subset, batch_size=args.batch_size, shuffle=False, collate_fn=partial(collate))
+
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model = build_model(
+            args.model,
+            len(ds.vocab),
+            len(ds.nmm_vocab),
+            len(ds.suffix_vocab),
+            len(ds.rnm_vocab),
+            len(ds.person_vocab),
+            len(ds.number_vocab),
+            len(ds.tense_vocab),
+            len(ds.aspect_vocab),
+            len(ds.mode_vocab),
+            num_nodes=ds.num_nodes,
+        )
+        checkpoint = torch.load(args.checkpoint, map_location=device)
+        state_dict = checkpoint.get("model_state", checkpoint)
+        model.load_state_dict(state_dict)
+        model.to(device)
+        inv_vocab = {v: k for k, v in ds.vocab.items()}
+        wer, cer, _ = compute_metrics(model, dl, inv_vocab, device)
+        print(json.dumps({"wer": wer, "cer": cer}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_architecture_benchmark.py
+++ b/tests/test_architecture_benchmark.py
@@ -1,0 +1,61 @@
+import json
+import numpy as np
+import pandas as pd
+import h5py
+import torch
+from torch.utils.data import DataLoader
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from train import SignDataset, collate, build_model
+from evaluate import compute_metrics
+
+
+def _create_eval_data(h5_path, csv_path):
+    with h5py.File(h5_path, "w") as h5:
+        for vid in ["s1.mp4", "s2.mp4"]:
+            grp = h5.create_group(vid)
+            T = 2
+            grp.create_dataset("pose", data=np.zeros((T, 33 * 3), np.float32))
+            grp.create_dataset("left_hand", data=np.zeros((T, 21 * 3), np.float32))
+            grp.create_dataset("right_hand", data=np.zeros((T, 21 * 3), np.float32))
+            grp.create_dataset("face", data=np.zeros((T, 468 * 3), np.float32))
+            grp.create_dataset("optical_flow", data=np.zeros((T, 2, 2, 2), np.float32))
+    pd.DataFrame({
+        "id": ["s1", "s2"],
+        "label": ["hello", "world"],
+        "nmm": ["neutral", "smile"],
+    }).to_csv(csv_path, sep=";", index=False)
+
+
+def _evaluate_model(name, ds, dl, inv_vocab):
+    model = build_model(
+        name,
+        len(ds.vocab),
+        len(ds.nmm_vocab),
+        len(ds.suffix_vocab),
+        len(ds.rnm_vocab),
+        len(ds.person_vocab),
+        len(ds.number_vocab),
+        len(ds.tense_vocab),
+        len(ds.aspect_vocab),
+        len(ds.mode_vocab),
+        num_nodes=ds.num_nodes,
+    )
+    wer, cer, _ = compute_metrics(model, dl, inv_vocab, torch.device("cpu"))
+    return {"wer": wer, "cer": cer}
+
+
+def test_compare_architectures(tmp_path):
+    h5_file = tmp_path / "data.h5"
+    csv_file = tmp_path / "labels.csv"
+    _create_eval_data(h5_file, csv_file)
+    with SignDataset(str(h5_file), str(csv_file)) as ds:
+        dl = DataLoader(ds, batch_size=1, shuffle=False, collate_fn=collate)
+        inv_vocab = {v: k for k, v in ds.vocab.items()}
+        results = {}
+        for name in ["stgcn", "sttn"]:
+            results[name] = _evaluate_model(name, ds, dl, inv_vocab)
+        print(json.dumps(results, indent=2))
+        assert set(results.keys()) == {"stgcn", "sttn"}


### PR DESCRIPTION
## Summary
- add script for computing WER/CER on a random validation subset with `evaluate.py`
- include a test to compare STGCN and STTN architectures on the same corpus
- document benchmark usage and data locations

## Testing
- `python scripts/evaluate_subset.py --help`
- `pytest tests/test_architecture_benchmark.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68915f7a83008331921b1c8737d7988c