### PR TITLE
Add config templates and validation for contrastive, distillation and vocab size

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -306,6 +306,18 @@ no se proporciona, se utilizará el valor definido en este archivo. Allí se
 especifican las rutas de los datasets, la carpeta de `checkpoints`, la
 arquitectura del modelo y los hiperparámetros más comunes.
 
+Además se incluyen plantillas específicas en `configs/` para distintos
+escenarios:
+
+- `config_distill.yaml`: habilita distillation (`distillation: true`) y
+  requiere un `teacher_ckpt` para entrenar un alumno.
+- `config_contrastive.yaml`: activa la opción `contrastive` para añadir una
+  pérdida contrastiva durante el entrenamiento.
+- `config_vocab_1k.yaml` y `config_vocab_32k.yaml`: ejemplifican cómo fijar
+  `vocab_size` al construir vocabularios pequeños o grandes.
+
+Use la plantilla que se ajuste a su caso como punto de partida.
+
 ---
 
 ## 6. Despliegue y Monitoreo

--- a/configs/config_contrastive.yaml
+++ b/configs/config_contrastive.yaml
@@ -1,4 +1,4 @@
-# Knowledge distillation training example
+# Contrastive training example
 
 dataset:
   h5_file: data/data.h5
@@ -8,16 +8,14 @@ dataset:
 
 checkpoints:
   dir: checkpoints
-  teacher_ckpt: checkpoints/teacher.pt
 
 model:
   arch: stgcn
 
 hyperparameters:
-  distillation: true
   epochs: 10
   batch_size: 4
   seq_len: 16
   max_seq_len: 128
   learning_rate: 0.001
-  aux_loss_weight: 0.1
+  contrastive: true

--- a/configs/config_vocab_1k.yaml
+++ b/configs/config_vocab_1k.yaml
@@ -1,23 +1,21 @@
-# Knowledge distillation training example
+# Configuration with small vocabulary size (1k tokens)
 
 dataset:
   h5_file: data/data.h5
   features_h5: data/features.h5
   csv_file: data/labels.csv
   vocab: vocab.txt
+  vocab_size: 1000
 
 checkpoints:
   dir: checkpoints
-  teacher_ckpt: checkpoints/teacher.pt
 
 model:
   arch: stgcn
 
 hyperparameters:
-  distillation: true
   epochs: 10
   batch_size: 4
   seq_len: 16
   max_seq_len: 128
   learning_rate: 0.001
-  aux_loss_weight: 0.1

--- a/configs/config_vocab_32k.yaml
+++ b/configs/config_vocab_32k.yaml
@@ -1,23 +1,21 @@
-# Knowledge distillation training example
+# Configuration with large vocabulary size (32k tokens)
 
 dataset:
   h5_file: data/data.h5
   features_h5: data/features.h5
   csv_file: data/labels.csv
   vocab: vocab.txt
+  vocab_size: 32000
 
 checkpoints:
   dir: checkpoints
-  teacher_ckpt: checkpoints/teacher.pt
 
 model:
   arch: stgcn
 
 hyperparameters:
-  distillation: true
   epochs: 10
   batch_size: 4
   seq_len: 16
   max_seq_len: 128
   learning_rate: 0.001
-  aux_loss_weight: 0.1


### PR DESCRIPTION
## Summary
- add configuration templates for distillation, contrastive loss and small/large vocabularies
- validate contrastive, distillation and vocab_size options in `utils/config.py`
- document the new templates and options in Readme

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'fastapi', 'torch', 'h5py', 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68915f77ee6483318ee4ca632751645d