### PR TITLE
Add domain CSV generator and update DANN docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -261,15 +261,27 @@ id;domain
 0003;0
 ```
 
+Este CSV puede generarse automáticamente combinando los `meta.csv` de distintos corpus:
+
+```bash
+python scripts/generate_domain_csv.py data/domains.csv data/corpus_a/train data/corpus_b/train
+```
+
+El orden de las rutas define el identificador de dominio asignado (0, 1, 2, ...).
+
 Para entrenar con DANN:
 
 ```bash
 python train.py --h5_file datos.h5 --csv_file labels.csv \
-  --domain_csv data/domain_labels_example.csv --adversarial \
+  --domain_csv data/domains.csv --adversarial \
   --adv_mix_rate 1.0 --adv_weight 0.1 --adv_steps 1
 ```
 
-Los parámetros `--adv_mix_rate` controla la lambda del gradiente invertido, `--adv_weight` pondera la pérdida adversarial y `--adv_steps` define cuántas iteraciones de actualización se realizan sobre el discriminador por batch.
+donde:
+
+* `adv_mix_rate` controla la λ del **Gradient Reversal Layer** (0–1).
+* `adv_weight` pondera la pérdida adversarial frente a la principal.
+* `adv_steps` indica cuántas actualizaciones se aplican al discriminador por mini‑batch.
 
 ---
 

--- a/configs/config_dann.yaml
+++ b/configs/config_dann.yaml
@@ -1,9 +1,9 @@
 # Domain-Adversarial Neural Network training example
 
 dataset:
-  h5_file: data/data.h5
-  features_h5: data/features.h5
-  csv_file: data/labels.csv
+  h5_file: data/lsa_t/train.h5
+  features_h5: data/lsa_t/features.h5
+  csv_file: data/lsa_t/labels.csv
   domain_csv: data/domains.csv
   vocab: vocab.txt
 
@@ -15,12 +15,12 @@ model:
   arch: stgcn
 
 hyperparameters:
-  epochs: 10
-  batch_size: 4
+  epochs: 30
+  batch_size: 8
   seq_len: 16
   max_seq_len: 128
-  learning_rate: 0.001
+  learning_rate: 0.0005
   adversarial: true
-  adv_mix_rate: 0.5
+  adv_mix_rate: 1.0
   adv_weight: 0.1
   adv_steps: 1

--- a/scripts/generate_domain_csv.py
+++ b/scripts/generate_domain_csv.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Generate domain label CSV for adversarial training.
+
+This utility combines the ``meta.csv`` files from multiple datasets and
+assigns a numeric domain id to each sample. The resulting CSV contains two
+columns separated by ``;``: ``id`` and ``domain``. Domains are enumerated in
+the same order as the input paths starting from 0.
+
+Example
+-------
+    python scripts/generate_domain_csv.py data/domains.csv data/lsa_t/train data/phoenix/train
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+def _read_ids(path: str | Path) -> Iterable[str]:
+    """Return the sequence ids from a ``meta.csv`` located at *path*.
+
+    ``path`` can be either a directory containing ``meta.csv`` or the path to
+    the CSV file itself. The file must contain an ``id`` column.
+    """
+
+    p = Path(path)
+    if p.is_dir():
+        p = p / "meta.csv"
+    if not p.is_file():
+        raise FileNotFoundError(f"meta.csv not found in {path}")
+    df = pd.read_csv(p, sep=";")
+    if "id" not in df.columns:
+        raise ValueError(f"'id' column missing in {p}")
+    return df["id"].astype(str)
+
+
+def generate(output_csv: str, inputs: list[str]) -> None:
+    rows = []
+    for domain, inp in enumerate(inputs):
+        ids = _read_ids(inp)
+        rows.append(pd.DataFrame({"id": ids, "domain": domain}))
+    out_df = pd.concat(rows, ignore_index=True)
+    out_df.to_csv(output_csv, sep=";", index=False)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Build domain CSV for DANN")
+    p.add_argument("output_csv", help="Path to output CSV")
+    p.add_argument(
+        "inputs",
+        nargs="+",
+        help="Dataset directories or meta.csv files. Order defines domain id",
+    )
+    args = p.parse_args()
+    generate(args.output_csv, args.inputs)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    main()


### PR DESCRIPTION
## Summary
- add utility to generate domain CSVs from multiple corpora
- document adversarial training options and new script
- provide example DANN configuration with realistic paths

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'nn' from '<unknown module name>' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68915f2632608331bbc225e4d6591f0d