### PR TITLE
Add LM transcript tools and docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,36 @@ Instale PyTorch con la versi\xC3\xB3n de CUDA apropiada desde [pytorch.org](http
 - `LM_CKPT`: checkpoint del modelo de lenguaje opcional.
 - `BEAM_SIZE` y `LM_WEIGHT`: par\xC3\xA1metros del decodificador beam-search.
 
+### Entrenamiento del modelo de lenguaje
+
+El script `train_lm.py` construye un vocabulario y entrena un
+`TransformerLanguageModel` a partir de un corpus de transcripciones en texto
+plano. El flujo b\xE1sico es:
+
+1. `build_vocab` crea `vocab.txt` con los tokens encontrados en el corpus.
+2. `TextDataset` segmenta cada l\xEDnea en secuencias de entrada/salida,
+   agregando los tokens especiales `<sos>` y `<eos>`.
+3. `train_model` optimiza el modelo y se guarda el checkpoint resultante.
+
+Ejemplo de uso:
+
+```bash
+python train_lm.py corpus.txt --vocab vocab.txt --output checkpoints/lm.pt
+```
+
+Para aprovechar el LM durante la decodificaci\xF3n se carga con
+`models.transformer_lm.load_model` y se pasa al decodificador
+(`infer.py`):
+
+```python
+from models.transformer_lm import load_model
+lm = load_model("checkpoints/lm.pt", vocab_size=len(vocab))
+```
+
+En la interfaz de l\xEDnea de comandos, el mismo comportamiento se logra
+indicando los argumentos `--lm` y `--vocab` o definiendo la variable de
+entorno `LM_CKPT`.
+
 ### Uso de la API
 
 Para exponer el servicio de transcripción ejecute:

--- a/data/compile_transcripts.py
+++ b/data/compile_transcripts.py
@@ -1,0 +1,60 @@
+"""Utilidades para unir transcripciones de múltiples corpora.
+
+Este script recorre los archivos de texto de uno o varios directorios y
+concatena todas las líneas en un único archivo de salida. Cada línea del
+archivo resultante corresponde a una transcripción.
+
+Ejemplo de uso::
+
+    python data/compile_transcripts.py corpus1 corpus2 -o salida.txt
+
+Donde ``corpus1`` y ``corpus2`` pueden ser directorios o archivos de texto.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def iter_transcripts(paths: Iterable[Path]) -> Iterable[str]:
+    """Genera transcripciones encontradas en ``paths``.
+
+    Si un elemento es un archivo, se leen todas sus líneas. Si es un directorio
+    se buscan archivos ``.txt`` de forma recursiva.
+    """
+
+    for p in paths:
+        if p.is_file():
+            with p.open("r", encoding="utf-8") as f:
+                for line in f:
+                    text = line.strip()
+                    if text:
+                        yield text
+        elif p.is_dir():
+            for txt in p.rglob("*.txt"):
+                with txt.open("r", encoding="utf-8") as f:
+                    for line in f:
+                        text = line.strip()
+                        if text:
+                            yield text
+        else:  # pragma: no cover - rutas inexistentes
+            continue
+
+
+def main() -> None:  # pragma: no cover - CLI fino
+    parser = argparse.ArgumentParser(description="Compila transcripciones")
+    parser.add_argument("paths", nargs="+", type=Path, help="Archivos o carpetas con transcripciones")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="Archivo de salida")
+    args = parser.parse_args()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as out:
+        for line in iter_transcripts(args.paths):
+            out.write(f"{line}\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - invocación directa
+    main()

--- a/tests/test_train_lm.py
+++ b/tests/test_train_lm.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+import torch
+from torch.utils.data import DataLoader
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from train_lm import build_vocab, TextDataset, train_model  # type: ignore
+from models.transformer_lm import TransformerLanguageModel, load_model
+
+
+def test_train_and_load_lm(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus.txt"
+    corpus.write_text("hola mundo\n")
+
+    vocab_path = tmp_path / "vocab.txt"
+    vocab = build_vocab(corpus, vocab_path)
+
+    ds = TextDataset(corpus, vocab, seq_len=3)
+    loader = DataLoader(ds, batch_size=1)
+
+    model = TransformerLanguageModel(len(vocab))
+    train_model(model, loader, epochs=1, lr=1e-2, pad_id=vocab["<pad>"], device=torch.device("cpu"))
+
+    ckpt = tmp_path / "lm.pt"
+    torch.save(model.state_dict(), ckpt)
+
+    lm = load_model(str(ckpt), vocab_size=len(vocab))
+    x = torch.tensor([[vocab["<sos>"], vocab["hola"], vocab["mundo"]]])
+    with torch.no_grad():
+        out = lm(x)
+    assert out.shape == (1, 3, len(vocab))


### PR DESCRIPTION
## Summary
- document language model training and loading in `Readme.md`
- add `compile_transcripts.py` helper to merge corpora transcripts into a single text file
- add regression test that trains a tiny LM and loads its checkpoint

## Testing
- `pytest tests/test_train_lm.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68915f10b0a0833180fba8af037958a4