### PR TITLE
feat(frontend): add recording controls and styling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -411,7 +411,21 @@ El backend se implementa con **FastAPI** y gRPC en contenedores Docker orquestad
 
 ### 6.2 Frontend en Tiempo Real
 
-Un cliente React/WebSocket captura la webcam o stream, envía chunks al servidor y superpone landmarks y transcripción en tiempo real para feedback inmediato al usuario .
+Un cliente React/WebSocket captura la webcam o stream, envía chunks al
+servidor y superpone transcripción en tiempo real para feedback inmediato al
+usuario.
+
+Para lanzar la interfaz web de desarrollo utilice:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+El servidor de Vite quedará expuesto en `http://localhost:5173` y se conectará
+al backend de FastAPI disponible en `ws://localhost:8000/ws`. Para generar una
+versión lista para producción ejecute `npm run build`.
 
 ### 6.3 Mantenimiento y Aprendizaje Continuo
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,37 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 2rem;
+}
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+video {
+  width: 100%;
+  height: auto;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.controls {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+.transcript-box {
+  margin-top: 1rem;
+}
+.transcript-box textarea {
+  width: 100%;
+  height: 150px;
+  resize: none;
+}
+.status {
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add recording controls, file upload support, and transcript history to React frontend
- introduce shared stylesheet and document how to run the frontend
- ignore Node build artifacts in git

## Testing
- `npm run build`
- `pytest tests/test_api_validations.py`
- `pytest tests/test_websocket_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c0a090a48331b26ac08ba7b0bf7b